### PR TITLE
Expose is_trending field on protocols endpoint

### DIFF
--- a/internal/api/handlers/protocols.go
+++ b/internal/api/handlers/protocols.go
@@ -34,6 +34,7 @@ type Protocol struct {
 	BackgroundURL               string   `json:"background_url,omitempty"`
 	Description                 string   `json:"description"`
 	IsBlacklisted               bool     `json:"is_blacklisted"`
+	IsTrending                  *bool    `json:"is_trending,omitempty"`
 	IsWalletConnectNotSupported bool     `json:"is_wc_not_supported"`
 }
 

--- a/internal/api/handlers/protocols_test.go
+++ b/internal/api/handlers/protocols_test.go
@@ -38,9 +38,12 @@ func TestGetProtocols(t *testing.T) {
 		assert.Equal(t, "https://freighter-protocol-icons-dev.stellar.org/protocol-backgrounds/blend.png", protocols[0].BackgroundURL)
 		assert.Equal(t, "Blend is a DeFi protocol that allows any entity to create or utilize an immutable lending market that fits its needs.", protocols[0].Description)
 		assert.Equal(t, false, protocols[0].IsBlacklisted)
+		require.NotNil(t, protocols[0].IsTrending)
+		assert.Equal(t, true, *protocols[0].IsTrending)
 		assert.Equal(t, true, protocols[0].IsWalletConnectNotSupported)
 		assert.Equal(t, "Phoenix", protocols[1].Name)
 		assert.Equal(t, true, protocols[1].IsBlacklisted)
+		assert.Nil(t, protocols[1].IsTrending)
 		assert.Equal(t, false, protocols[1].IsWalletConnectNotSupported)
 		assert.Equal(t, "Allbridge Core", protocols[2].Name)
 
@@ -56,6 +59,8 @@ func TestGetProtocols(t *testing.T) {
 		require.NoError(t, err)
 		_, hasBackgroundURL := raw.Data.Protocols[2]["background_url"]
 		assert.False(t, hasBackgroundURL, "background_url key should be absent for protocols without a background image")
+		_, hasTrending := raw.Data.Protocols[2]["is_trending"]
+		assert.False(t, hasTrending, "is_trending key should be absent for protocols without a trending flag")
 	})
 	t.Run("should return error if protocols file is not found", func(t *testing.T) {
 		t.Parallel()

--- a/internal/api/handlers/testdata/protocols.json
+++ b/internal/api/handlers/testdata/protocols.json
@@ -6,6 +6,7 @@
       "icon_url": "https://freighter-protocol-icons-dev.stellar.org/protocol-icons/blend.svg",
       "background_url": "https://freighter-protocol-icons-dev.stellar.org/protocol-backgrounds/blend.png",
       "description": "Blend is a DeFi protocol that allows any entity to create or utilize an immutable lending market that fits its needs.",
+      "is_trending": true,
       "is_wc_not_supported": true
     },
     {

--- a/internal/integrationtests/infrastructure/testdata/protocols.json
+++ b/internal/integrationtests/infrastructure/testdata/protocols.json
@@ -6,6 +6,7 @@
       "icon_url": "https://freighter-protocol-icons-dev.stellar.org/protocol-icons/blend.svg",
       "background_url": "https://freighter-protocol-icons-dev.stellar.org/protocol-backgrounds/blend.png",
       "description": "Blend is a DeFi protocol that allows any entity to create or utilize an immutable lending market that fits its needs.",
+      "is_trending": true,
       "is_blacklisted": false
     },
     {

--- a/internal/integrationtests/protocols_test.go
+++ b/internal/integrationtests/protocols_test.go
@@ -75,6 +75,8 @@ func (s *ProtocolsTestSuite) TestGetProtocolsReturns200StatusCodeForValidProtoco
 	assert.Equal(t, "https://freighter-protocol-icons-dev.stellar.org/protocol-backgrounds/blend.png", protocols[0].BackgroundURL)
 	assert.Equal(t, "Blend is a DeFi protocol that allows any entity to create or utilize an immutable lending market that fits its needs.", protocols[0].Description)
 	assert.Equal(t, false, protocols[0].IsBlacklisted)
+	require.NotNil(t, protocols[0].IsTrending)
+	assert.Equal(t, true, *protocols[0].IsTrending)
 	assert.Equal(t, "Phoenix", protocols[1].Name)
 	assert.Equal(t, "Allbridge Core", protocols[2].Name)
 
@@ -92,6 +94,10 @@ func (s *ProtocolsTestSuite) TestGetProtocolsReturns200StatusCodeForValidProtoco
 	assert.False(t, phoenixHasBackgroundURL, "background_url key should be absent for protocols without a background image")
 	_, allbridgeHasBackgroundURL := raw.Data.Protocols[2]["background_url"]
 	assert.False(t, allbridgeHasBackgroundURL, "background_url key should be absent for protocols without a background image")
+	_, phoenixHasTrending := raw.Data.Protocols[1]["is_trending"]
+	assert.False(t, phoenixHasTrending, "is_trending key should be absent for protocols without a trending flag")
+	_, allbridgeHasTrending := raw.Data.Protocols[2]["is_trending"]
+	assert.False(t, allbridgeHasTrending, "is_trending key should be absent for protocols without a trending flag")
 }
 
 func (s *ProtocolsTestSuite) TestGetProtocolsReturns500StatusCodeForInvalidProtocols() {


### PR DESCRIPTION
Adds an `is_trending` boolean flag to the `/api/v1/protocols` response so the frontend can highlight trending protocols in the Freighter wallet UI.

The field uses `*bool` with `omitempty` — protocols without the flag set will omit the key entirely from the JSON response, keeping the payload lean and backward-compatible.

## Changes

- `Protocol` struct: added `IsTrending *bool` with `json:"is_trending,omitempty"`
- Unit and integration testdata updated with `is_trending: true` for Blend
- Unit tests: assert `is_trending` is present and `true` when set, `nil` when absent, and the key is omitted from the JSON for protocols without it
- Integration tests: same assertions applied end-to-end
