### PR TITLE
Add contributing guide with LLM quick start instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ See `Makefile` for the complete list.
 ## Code Conventions
 
 - **Formatting:** `gofmt` and `gofumpt`
-- **Linting:** `golangci-lint` (5m timeout)
+- **Linting:** `golangci-lint` (local: default timeout via `make lint`; CI: `--timeout=5m`)
 - **Import organization:** `goimports` with local prefix
   `github.com/stellar/freighter-backend-v2`
 - **Tests:** All changes must be covered. Coverage threshold: 80%.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ For the Stellar organization's general contribution guidelines, see the
 | ------------- | --------- | ------------------------------------------------------------------ |
 | Go            | >= 1.24.0 | [go.dev/dl](https://go.dev/dl/) (toolchain 1.24.2)                |
 | Docker        | Latest    | [docker.com](https://docs.docker.com/get-docker/) (for Redis)     |
+| Docker Compose| Latest    | Included with Docker Desktop or install the [Compose plugin](https://docs.docker.com/compose/install/) |
+| Make          | Latest    | Pre-installed on macOS; `sudo apt install make` on Linux           |
 | golangci-lint | Latest    | `brew install golangci-lint` or [docs](https://golangci-lint.run/) |
 
 ## Getting Started
@@ -33,9 +35,9 @@ If you don't use an LLM assistant, follow the manual setup below.
 git clone https://github.com/stellar/freighter-backend-v2.git
 cd freighter-backend-v2
 cp configs/.toml-EXAMPLE configs/.toml    # Then fill in values (see below)
-docker compose -f deployments/docker-compose.yml up -d  # Start Redis
+docker compose -f deployments/docker-compose.yml up -d redis  # Start Redis only
 make build
-make run
+./freighter-backend serve --config-path configs/.toml
 ```
 
 ### Configuration
@@ -49,9 +51,9 @@ Copy `configs/.toml-EXAMPLE` to `configs/.toml`. For local development:
 | `FREIGHTER_BACKEND_PORT` | `3002`                                               |
 | `FREIGHTER_BACKEND_HOST` | `localhost`                                          |
 | `MODE`                   | `development`                                        |
-| `RPC_URL`                | A Stellar RPC endpoint (e.g., `https://soroban-testnet.stellar.org`) |
 | `TESTNET_RPC_URL`        | `https://soroban-testnet.stellar.org`                |
 | `PUBNET_RPC_URL`         | `https://soroban.stellar.org` (or leave as `not-set`) |
+| `FUTURENET_RPC_URL`      | Leave as `not-set` unless testing futurenet           |
 | `REDIS_HOST`             | `localhost`                                          |
 | `REDIS_PORT`             | `6379`                                               |
 
@@ -69,11 +71,11 @@ Copy `configs/.toml-EXAMPLE` to `configs/.toml`. For local development:
 ```bash
 make check              # All quality checks (lint, fmt, vet, shadow, etc.)
 make unit-test          # Unit tests
-make unit-test-coverage # Unit tests with 80% coverage threshold
+make unit-test-coverage # Generate coverage report (80% threshold enforced in CI)
 make integration-test   # Integration tests (uses testcontainers)
 make build              # Build binary
-make run                # Run the server
-make docker-up          # Docker Compose up
+./freighter-backend serve --config-path configs/.toml  # Run the server
+make docker-up          # Docker Compose up (all services)
 ```
 
 See `Makefile` for the complete list.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,11 @@ For the Stellar organization's general contribution guidelines, see the
 ### Quick Setup with an LLM
 
 If you use an LLM-powered coding assistant, you can automate the setup. The repo
-includes a quick start guide ([`LLM-QUICK-START.md`](LLM-QUICK-START.md)) that
+includes a quick start guide ([`quick-start-guide.md`](quick-start-guide.md)) that
 checks your environment, installs missing tools, configures the app, and verifies
 the build.
 
-Point your LLM assistant at `LLM-QUICK-START.md` and ask it to follow the steps.
+Point your LLM assistant at `quick-start-guide.md` and ask it to follow the steps.
 
 If you don't use an LLM assistant, follow the manual setup below.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to Freighter Backend V2
+
+Go backend service for the Freighter wallet. Provides collectibles, RPC health
+checks, ledger key accounts, protocol info, and Blockaid scanning.
+
+For the Stellar organization's general contribution guidelines, see the
+[Stellar Contribution Guide](https://github.com/stellar/.github/blob/master/CONTRIBUTING.md).
+
+## Prerequisites
+
+| Tool          | Version   | Install                                                            |
+| ------------- | --------- | ------------------------------------------------------------------ |
+| Go            | >= 1.24.0 | [go.dev/dl](https://go.dev/dl/) (toolchain 1.24.2)                |
+| Docker        | Latest    | [docker.com](https://docs.docker.com/get-docker/) (for Redis)     |
+| golangci-lint | Latest    | `brew install golangci-lint` or [docs](https://golangci-lint.run/) |
+
+## Getting Started
+
+### Quick Setup with an LLM
+
+If you use an LLM-powered coding assistant, you can automate the setup. The repo
+includes a quick start guide ([`LLM-QUICK-START.md`](LLM-QUICK-START.md)) that
+checks your environment, installs missing tools, configures the app, and verifies
+the build.
+
+Point your LLM assistant at `LLM-QUICK-START.md` and ask it to follow the steps.
+
+If you don't use an LLM assistant, follow the manual setup below.
+
+### Manual Setup
+
+```bash
+git clone https://github.com/stellar/freighter-backend-v2.git
+cd freighter-backend-v2
+cp configs/.toml-EXAMPLE configs/.toml    # Then fill in values (see below)
+docker compose -f deployments/docker-compose.yml up -d  # Start Redis
+make build
+make run
+```
+
+### Configuration
+
+Copy `configs/.toml-EXAMPLE` to `configs/.toml`. For local development:
+
+**Required:**
+
+| Variable                 | Value for local dev                                  |
+| ------------------------ | ---------------------------------------------------- |
+| `FREIGHTER_BACKEND_PORT` | `3002`                                               |
+| `FREIGHTER_BACKEND_HOST` | `localhost`                                          |
+| `MODE`                   | `development`                                        |
+| `RPC_URL`                | A Stellar RPC endpoint (e.g., `https://soroban-testnet.stellar.org`) |
+| `TESTNET_RPC_URL`        | `https://soroban-testnet.stellar.org`                |
+| `PUBNET_RPC_URL`         | `https://soroban.stellar.org` (or leave as `not-set`) |
+| `REDIS_HOST`             | `localhost`                                          |
+| `REDIS_PORT`             | `6379`                                               |
+
+**Optional — features degrade gracefully:**
+
+| Variable                | Purpose               | Notes                            |
+| ----------------------- | --------------------- | -------------------------------- |
+| `SENTRY_KEY`            | Error tracking        | Leave as `not-set` for local dev |
+| `BLOCKAID_API_KEY`      | Transaction scanning  | Leave as `not-set` for local dev |
+| `COINBASE_API_KEY/SECRET` | Pricing data        | Leave as `not-set` for local dev |
+| `HORIZON_*_URL`         | Horizon endpoints     | Defaults work for most dev tasks |
+
+## Key Commands
+
+```bash
+make check              # All quality checks (lint, fmt, vet, shadow, etc.)
+make unit-test          # Unit tests
+make unit-test-coverage # Unit tests with 80% coverage threshold
+make integration-test   # Integration tests (uses testcontainers)
+make build              # Build binary
+make run                # Run the server
+make docker-up          # Docker Compose up
+```
+
+See `Makefile` for the complete list.
+
+## Code Conventions
+
+- **Formatting:** `gofmt` and `gofumpt`
+- **Linting:** `golangci-lint` (5m timeout)
+- **Import organization:** `goimports` with local prefix
+  `github.com/stellar/freighter-backend-v2`
+- **Tests:** All changes must be covered. Coverage threshold: 80%.
+- **Documentation:** Doc comments on all exported functions per
+  [Effective Go](https://golang.org/doc/effective_go.html#commentary)
+
+## Testing
+
+**Unit tests:**
+```bash
+make unit-test
+```
+
+**Integration tests** (uses `testcontainers-go` for Redis):
+```bash
+make integration-test
+```
+
+## Pull Requests
+
+- Branch from `main`
+- Commit messages: action verb in present tense
+- Code must pass `make check`
+- All tests must pass with 80% coverage
+- Follow [Effective Go](https://golang.org/doc/effective_go.html)
+
+**CI runs on every PR:** check + build + unit-tests (80% coverage) +
+integration-tests. See `.github/workflows/go.yaml`.
+
+## Related Repositories
+
+- [stellar/freighter-backend](https://github.com/stellar/freighter-backend)
+  (TypeScript) — V1 backend for balances, subscriptions, feature flags
+- [stellar/freighter](https://github.com/stellar/freighter) — Browser extension
+- [stellar/freighter-mobile](https://github.com/stellar/freighter-mobile) — Mobile app
+
+## Security
+
+- **Never log** API keys, auth credentials, or user data
+- **Blockaid integration** protects users — don't bypass or weaken
+- **Report vulnerabilities** via the
+  [Stellar Security Policy](https://github.com/stellar/.github/blob/master/SECURITY.md)
+  — not public issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ For the Stellar organization's general contribution guidelines, see the
 | Docker Compose| Latest    | Included with Docker Desktop or install the [Compose plugin](https://docs.docker.com/compose/install/) |
 | Make          | Latest    | Pre-installed on macOS; `sudo apt install make` on Linux           |
 | golangci-lint | Latest    | `brew install golangci-lint` or [docs](https://golangci-lint.run/) |
+| gofumpt       | Latest    | `go install mvdan.cc/gofumpt@latest`                               |
 
 ## Getting Started
 

--- a/LLM-QUICK-START.md
+++ b/LLM-QUICK-START.md
@@ -1,0 +1,105 @@
+# Freighter Backend V2 — LLM Quick Start
+
+Evaluate the contributor's machine against all prerequisites for
+freighter-backend-v2 (Go), install what's missing, and run the initial setup.
+
+## Step 1: Check all prerequisites
+
+Run every check and collect results. Report all at once.
+
+```bash
+# Go >= 1.24.0
+go version 2>&1 || which go
+
+# Docker (needed for Redis)
+docker --version 2>&1 || which docker
+
+# Docker Compose
+docker compose version 2>&1 || which docker-compose
+
+# golangci-lint
+golangci-lint --version 2>&1 || which golangci-lint
+
+# Make
+make --version 2>&1 | head -1 || which make
+```
+
+## Step 2: Present results
+
+```
+Freighter Backend V2 — Prerequisites Check
+============================================
+  Go             1.24.2         >= 1.24.0 required    OK
+  Docker         27.x.x         any (for Redis)       OK
+  Docker Compose 2.x.x          any                   OK
+  golangci-lint  1.x.x          any                   OK
+  Make           3.x            any                   OK
+```
+
+## Step 3: Install missing tools
+
+Present missing tools and ask the user to confirm before installing.
+
+**Auto-installable (run after user confirms):**
+
+- **Go**: `brew install go` (macOS) or download from [go.dev/dl](https://go.dev/dl/)
+- **Docker**: `brew install --cask docker` (macOS) or follow
+  [docs.docker.com](https://docs.docker.com/engine/install/) (Linux)
+- **golangci-lint**: `brew install golangci-lint` (macOS) or
+  `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
+
+## Step 4: Configure
+
+Check if `configs/.toml` exists. If not:
+
+```bash
+cp configs/.toml-EXAMPLE configs/.toml
+```
+
+Set these for local development:
+
+| Variable                 | Value                                    |
+| ------------------------ | ---------------------------------------- |
+| `FREIGHTER_BACKEND_PORT` | `3002`                                   |
+| `FREIGHTER_BACKEND_HOST` | `localhost`                              |
+| `MODE`                   | `development`                            |
+| `RPC_URL`                | `https://soroban-testnet.stellar.org`    |
+| `TESTNET_RPC_URL`        | `https://soroban-testnet.stellar.org`    |
+| `REDIS_HOST`             | `localhost`                              |
+| `REDIS_PORT`             | `6379`                                   |
+
+Other variables can stay as `not-set` for local dev.
+
+## Step 5: Run initial setup
+
+```bash
+# Start Redis
+docker compose -f deployments/docker-compose.yml up -d
+
+# Build and run
+make build
+make run
+```
+
+## Step 6: Verify
+
+```bash
+make check        # All quality checks
+make unit-test    # Unit tests (80% coverage threshold)
+```
+
+## Step 7: Summary
+
+```
+Setup Complete
+==============
+  Prerequisites: [list with versions]
+  Configured: configs/.toml from .toml-EXAMPLE
+
+  Ready to run:
+  1. docker compose -f deployments/docker-compose.yml up -d  (start Redis)
+  2. make run                                                 (start server)
+
+  Manual action needed:
+  - [ ] Set RPC_URL to a Stellar RPC endpoint
+```

--- a/LLM-QUICK-START.md
+++ b/LLM-QUICK-START.md
@@ -21,7 +21,11 @@ docker compose version 2>&1 || which docker-compose
 golangci-lint --version 2>&1 || which golangci-lint
 
 # Make
-make --version 2>&1 | head -1 || which make
+if command -v make >/dev/null 2>&1; then
+  make --version 2>&1 | head -1
+else
+  which make
+fi
 ```
 
 ## Step 2: Present results

--- a/LLM-QUICK-START.md
+++ b/LLM-QUICK-START.md
@@ -63,8 +63,9 @@ Set these for local development:
 | `FREIGHTER_BACKEND_PORT` | `3002`                                   |
 | `FREIGHTER_BACKEND_HOST` | `localhost`                              |
 | `MODE`                   | `development`                            |
-| `RPC_URL`                | `https://soroban-testnet.stellar.org`    |
 | `TESTNET_RPC_URL`        | `https://soroban-testnet.stellar.org`    |
+| `PUBNET_RPC_URL`         | `https://soroban.stellar.org` (or `not-set`) |
+| `FUTURENET_RPC_URL`      | `not-set` (unless testing futurenet)     |
 | `REDIS_HOST`             | `localhost`                              |
 | `REDIS_PORT`             | `6379`                                   |
 
@@ -74,7 +75,7 @@ Other variables can stay as `not-set` for local dev.
 
 ```bash
 # Start Redis
-docker compose -f deployments/docker-compose.yml up -d
+docker compose -f deployments/docker-compose.yml up -d redis
 
 # Build and run
 make build
@@ -84,8 +85,9 @@ make run
 ## Step 6: Verify
 
 ```bash
-make check        # All quality checks
-make unit-test    # Unit tests (80% coverage threshold)
+make check              # All quality checks
+make unit-test          # Unit tests
+make unit-test-coverage # Generate local coverage report (80% threshold enforced in CI)
 ```
 
 ## Step 7: Summary
@@ -97,9 +99,6 @@ Setup Complete
   Configured: configs/.toml from .toml-EXAMPLE
 
   Ready to run:
-  1. docker compose -f deployments/docker-compose.yml up -d  (start Redis)
-  2. make run                                                 (start server)
-
-  Manual action needed:
-  - [ ] Set RPC_URL to a Stellar RPC endpoint
+  1. docker compose -f deployments/docker-compose.yml up -d redis  (start Redis)
+  2. make run                                                       (start server)
 ```

--- a/LLM-QUICK-START.md
+++ b/LLM-QUICK-START.md
@@ -79,7 +79,7 @@ docker compose -f deployments/docker-compose.yml up -d redis
 
 # Build and run
 make build
-make run
+./freighter-backend serve --config-path configs/.toml
 ```
 
 ## Step 6: Verify
@@ -100,5 +100,5 @@ Setup Complete
 
   Ready to run:
   1. docker compose -f deployments/docker-compose.yml up -d redis  (start Redis)
-  2. make run                                                       (start server)
+  2. ./freighter-backend serve --config-path configs/.toml           (start server)
 ```

--- a/quick-start-guide.md
+++ b/quick-start-guide.md
@@ -1,4 +1,4 @@
-# Freighter Backend V2 — LLM Quick Start
+# Freighter Backend V2 — Quick Start Guide
 
 Evaluate the contributor's machine against all prerequisites for
 freighter-backend-v2 (Go), install what's missing, and run the initial setup.


### PR DESCRIPTION
# Skill Eval: `freighter-backend-v2-dev-setup` — Benchmark Report

**Date:** 2026-04-08
**Iterations:** 4
**Repo:** [stellar/freighter-backend-v2](https://github.com/stellar/freighter-backend-v2)
**Model:** Claude Opus 4.6
**Prompt:** "I just cloned freighter-backend-v2 and want to run it locally."

---

## Summary

| Metric | With Skill | Without Skill | Delta |
|---|---|---|---|
| Pass rate | **95%** | **70%** | +25pp |

The skill provides consistent guidance on the TOML config file (not a standard
`.env`), the `deployments/` directory for Docker Compose, and Stellar RPC URLs.

---

## Assertion Results (aggregated across 4 iterations)

| # | Assertion | With Skill | Without Skill |
|---|---|---|---|
| 1 | Checks Go version (>= 1.24.0) | 4/4 (100%) | 4/4 (100%) |
| 2 | Checks Docker availability | 4/4 (100%) | 4/4 (100%) |
| 3 | Checks golangci-lint | 4/4 (100%) | 2/4 (50%) |
| 4 | Detects config file missing (configs/.toml) | 4/4 (100%) | 3/4 (75%) |
| 5 | Lists required config vars (port, host, RPC URLs) | 4/4 (100%) | 2/4 (50%) |
| 6 | Notes docker-compose is in deployments/ (not root) | 3/4 (75%) | 2/4 (50%) |
| 7 | Provides Stellar RPC endpoint URLs | 4/4 (100%) | 2/4 (50%) |
| 8 | Mentions make check / make build / make run | 4/4 (100%) | 4/4 (100%) |
| 9 | Structured prerequisites table | 3/4 (75%) | 1/4 (25%) |
| 10 | Produces actionable summary | 4/4 (100%) | 2/4 (50%) |
| | **Overall** | **38/40 (95%)** | **28/40 (70%)** |