### PR TITLE
fix(internal): nil pointer panic in collectibles goroutines

### DIFF
--- a/internal/api/handlers/collectibles.go
+++ b/internal/api/handlers/collectibles.go
@@ -241,6 +241,16 @@ func (h *CollectiblesHandler) fetchMeridianPayCollectibles(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					results[i] = CollectionResult{
+						Error: &CollectionError{
+							ErrorMessage:      fmt.Sprintf("panic: %v", p),
+							CollectionAddress: contract,
+						},
+					}
+				}
+			}()
 
 			// Check context before starting work
 			select {

--- a/internal/api/handlers/collectibles_test.go
+++ b/internal/api/handlers/collectibles_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stellar/go-stellar-sdk/txnbuild"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -174,6 +175,51 @@ func TestFetchMeridianPayCollectibles(t *testing.T) {
 		assert.NotNil(t, res.Error)
 		assert.Contains(t, res.Error.ErrorMessage, "no collectibles fetched")
 	}
+}
+
+func TestFetchMeridianPayCollectibles_PanicRecovery(t *testing.T) {
+	// Mock that panics during SimulateInvocation — previously this would crash the process
+	mockRPC := &utils.MockRPCService{
+		SimulatePanic: true,
+	}
+	handler := NewCollectiblesHandler(mockRPC, "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA", "CDSN4MICK7U5XOP4DE6OIZQCRMYO3UTQ5VYZV7ZA7H63OICZPBLXYRGJ", "", 10)
+
+	account := &txnbuild.SimpleAccount{AccountID: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"}
+	ctx := context.Background()
+
+	// Should not panic — goroutines recover and return error results
+	results, err := handler.fetchMeridianPayCollectibles(ctx, account, account.AccountID, "PUBLIC")
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	for _, res := range results {
+		assert.Nil(t, res.Collection)
+		require.NotNil(t, res.Error)
+		assert.Contains(t, res.Error.ErrorMessage, "panic")
+	}
+}
+
+func TestFetchMeridianPayCollectibles_NonVecResponse(t *testing.T) {
+	// Simulate a contract returning a non-Vec type (e.g. on a different network)
+	nonVecResult := &xdr.ScVal{
+		Type: xdr.ScValTypeScvVoid,
+	}
+	mockRPC := &utils.MockRPCService{
+		SimulateResultOverride: nonVecResult,
+	}
+	handler := NewCollectiblesHandler(mockRPC, "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA", "", "", 10)
+
+	account := &txnbuild.SimpleAccount{AccountID: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"}
+	ctx := context.Background()
+
+	results, err := handler.fetchMeridianPayCollectibles(ctx, account, account.AccountID, "TESTNET")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	// Should get an error result, not a panic
+	assert.Nil(t, results[0].Collection)
+	require.NotNil(t, results[0].Error)
+	assert.Contains(t, results[0].Error.ErrorMessage, "fetching owner tokens")
 }
 
 func TestGetCollectibles_WithMeridianPayAddresses(t *testing.T) {

--- a/internal/api/handlers/utils.go
+++ b/internal/api/handlers/utils.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/alitto/pond/v2"
@@ -218,7 +219,12 @@ func fetchOwnerTokens(
 		return nil, err
 	}
 
-	tokenIDs, err := utils.ScVecToStrings(*res.Vec)
+	vec, ok := res.GetVec()
+	if !ok {
+		return nil, fmt.Errorf("expected SCV_VEC result, got %v", res.Type)
+	}
+
+	tokenIDs, err := utils.ScVecToStrings(vec)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/handlers/utils_test.go
+++ b/internal/api/handlers/utils_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stellar/freighter-backend-v2/internal/utils"
@@ -137,4 +138,21 @@ func TestFetchOwnerTokens_SimulateInvocationError(t *testing.T) {
 
 	_, err := fetchOwnerTokens(mockRPC, context.Background(), account, contractID, owner, "PUBLIC")
 	assert.Error(t, err)
+}
+
+func TestFetchOwnerTokens_NonVecResponse(t *testing.T) {
+	// Simulate a contract that returns a non-Vec type (e.g. SCV_VOID)
+	nonVecResult := &xdr.ScVal{
+		Type: xdr.ScValTypeScvVoid,
+	}
+	mockRPC := &utils.MockRPCService{
+		SimulateResultOverride: nonVecResult,
+	}
+	account := &txnbuild.SimpleAccount{AccountID: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"}
+	owner := "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+	contractID := "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA"
+
+	_, err := fetchOwnerTokens(mockRPC, context.Background(), account, contractID, owner, "PUBLIC")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected SCV_VEC result")
 }

--- a/internal/integrationtests/health_test.go
+++ b/internal/integrationtests/health_test.go
@@ -39,7 +39,7 @@ func (s *HealthTestSuite) TestGetRPCHealthReturns200StatusCode() {
 
 	resp, err := http.Get(fmt.Sprintf("%s/api/v1/rpc-health", s.connectionString))
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Verify the response body contains a status field with a valid value

--- a/internal/utils/mocks.go
+++ b/internal/utils/mocks.go
@@ -11,6 +11,8 @@ import (
 
 type MockRPCService struct {
 	SimulateError          error
+	SimulateResultOverride *xdr.ScVal
+	SimulatePanic          bool
 	TokenURIOverride       string
 	GetLedgerEntryOverride []types.LedgerEntryMap
 	GetLedgerEntryError    error
@@ -45,8 +47,16 @@ func (m *MockRPCService) SimulateInvocation(
 	timeout txnbuild.TimeBounds,
 	network string,
 ) (types.SimulateTransactionResponse, error) {
+	if m.SimulatePanic {
+		panic("simulated RPC panic")
+	}
+
 	if m.SimulateError != nil {
 		return nil, m.SimulateError
+	}
+
+	if m.SimulateResultOverride != nil {
+		return m.SimulateResultOverride, nil
 	}
 
 	fn := string(functionName)


### PR DESCRIPTION
What  
Add defer recover() to raw goroutines in `fetchMeridianPayCollectibles` and replace unsafe *res.Vec dereference with the safe GetVec() accessor. Previously, an RPC response with a non-Vec ScVal type would panic in a child goroutine that lacked recovery, terminating the entire process.