### PR TITLE
fix(ledger-key/accounts): max ledger keys for GetLedgerKeyAccounts

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -44,6 +44,7 @@ func (s *ServeCmd) Command() *cobra.Command {
 	cmd.Flags().StringVar(&s.Cfg.AppConfig.MeridianPayStellarHouseAddress, "meridian-pay-stellar-house-address", "", "The Meridian Pay Stellar House collection address")
 	cmd.Flags().Int64Var(&s.Cfg.AppConfig.MaxRequestBodySize, "max-request-body-size", 1<<20, "Maximum request body size in bytes (default: 1MB)")
 	cmd.Flags().IntVar(&s.Cfg.AppConfig.MaxBalanceAddresses, "max-balance-addresses", 100, "Maximum number of addresses allowed in account balances request")
+	cmd.Flags().IntVar(&s.Cfg.AppConfig.MaxLedgerKeyAddresses, "max-ledger-key-addresses", 100, "Maximum number of public keys allowed in a ledger-key/accounts request")
 
 	// RPC Config
 	cmd.Flags().StringVar(&s.Cfg.RpcConfig.PubnetRpcUrl, "pubnet-rpc-url", "", "The Pubnet URL of the Pubnet RPC instance")

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -1,10 +1,13 @@
 package serve
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/stellar/freighter-backend-v2/internal/api"
 	"github.com/stellar/freighter-backend-v2/internal/config"
+	"github.com/stellar/freighter-backend-v2/internal/services"
 	"github.com/stellar/freighter-backend-v2/internal/utils"
 )
 
@@ -20,6 +23,9 @@ func (s *ServeCmd) Command() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := utils.InitializeConfig(cmd); err != nil {
 				return err
+			}
+			if n := s.Cfg.AppConfig.MaxLedgerKeyAddresses; n > services.MaxLedgerEntryKeys {
+				return fmt.Errorf("--max-ledger-key-addresses=%d exceeds upstream Stellar RPC ceiling of %d keys per getLedgerEntries call", n, services.MaxLedgerEntryKeys)
 			}
 			return nil
 		},

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/freighter-backend-v2/internal/config"
+	"github.com/stellar/freighter-backend-v2/internal/services"
 )
 
 func TestServeCmd_Command(t *testing.T) {
@@ -83,4 +84,32 @@ func TestServeCmd_Execute(t *testing.T) {
 	assert.Contains(t, string(out), "freighter-backend-host=test_host")
 	assert.Contains(t, string(out), "mode=test_mode")
 	assert.True(t, configUsed)
+}
+
+func TestServeCmd_RejectsMaxLedgerKeyAddressesAboveUpstreamCeiling(t *testing.T) {
+	t.Parallel()
+
+	serveCmd := &ServeCmd{Cfg: &config.Config{}}
+	cmd := serveCmd.Command()
+	cmd.RunE = func(*cobra.Command, []string) error { return nil }
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--max-ledger-key-addresses", fmt.Sprintf("%d", services.MaxLedgerEntryKeys+1)})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds upstream Stellar RPC ceiling")
+}
+
+func TestServeCmd_AcceptsMaxLedgerKeyAddressesAtUpstreamCeiling(t *testing.T) {
+	t.Parallel()
+
+	serveCmd := &ServeCmd{Cfg: &config.Config{}}
+	cmd := serveCmd.Command()
+	cmd.RunE = func(*cobra.Command, []string) error { return nil }
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--max-ledger-key-addresses", fmt.Sprintf("%d", services.MaxLedgerEntryKeys)})
+
+	require.NoError(t, cmd.Execute())
 }

--- a/internal/api/handlers/ledger_key_accounts.go
+++ b/internal/api/handlers/ledger_key_accounts.go
@@ -24,14 +24,16 @@ const (
 )
 
 type LedgerKeyAccountHandler struct {
-	RpcService types.RPCService
+	RpcService    types.RPCService
+	MaxPublicKeys int
 }
 
 type LedgerKeyAccountMap map[string]types.AccountInfo
 
-func NewLedgerKeyAccountHandler(rpc types.RPCService) *LedgerKeyAccountHandler {
+func NewLedgerKeyAccountHandler(rpc types.RPCService, maxPublicKeys int) *LedgerKeyAccountHandler {
 	return &LedgerKeyAccountHandler{
-		RpcService: rpc,
+		RpcService:    rpc,
+		MaxPublicKeys: maxPublicKeys,
 	}
 }
 
@@ -68,12 +70,16 @@ func validateLedgerKeyAccountRequest(r *http.Request) (*LedgerKeyAccountRequest,
 	return &req, nil
 }
 
-func getLedgerKeyAccountKeys(publicKeys []string) (LedgerKeyAccountKeys, LedgerKeyAccountError) {
+func getLedgerKeyAccountKeys(ctx context.Context, publicKeys []string) (LedgerKeyAccountKeys, LedgerKeyAccountError) {
 	ledgerKeyAccountMap := LedgerKeyAccountMap{}
 	ledgerKeyAccountError := LedgerKeyAccountError{ErrorKeys: []PublicKeyError{}}
 	ledgerKeyAccountKeys := []string{}
 
 	for _, publicKey := range publicKeys {
+		if err := ctx.Err(); err != nil {
+			ledgerKeyAccountError.ErrorMessage = err.Error()
+			return LedgerKeyAccountKeys{LedgerKeys: ledgerKeyAccountKeys, LedgerKeyAccountMap: ledgerKeyAccountMap}, ledgerKeyAccountError
+		}
 		accountId, err := xdr.AddressToAccountId(publicKey)
 		if err != nil {
 			ledgerKeyAccountError.ErrorMessage = "error converting public key to account id"
@@ -115,12 +121,14 @@ func processLedgerKeyAccountsEntries(publicKeys []string, data []types.LedgerEnt
 	ledgerKeyAccountsMap := LedgerKeyAccountMap{}
 	ledgerKeyAccountsError := LedgerKeyAccountError{ErrorKeys: []PublicKeyError{}}
 
+	accountByID := make(map[string]types.AccountInfo, len(data))
+	for _, entry := range data {
+		accountByID[entry.Account.AccountId] = entry.Account
+	}
+
 	for _, publicKey := range publicKeys {
-		for _, entry := range data {
-			if entry.Account.AccountId == publicKey {
-				ledgerKeyAccountsMap[publicKey] = entry.Account
-				break
-			}
+		if account, ok := accountByID[publicKey]; ok {
+			ledgerKeyAccountsMap[publicKey] = account
 		}
 	}
 
@@ -147,9 +155,14 @@ func (h *LedgerKeyAccountHandler) GetLedgerKeyAccounts(w http.ResponseWriter, r 
 		return httperror.BadRequest(fmt.Sprintf("%s: %s", "Invalid request - public keys are required", err.Error()), err)
 	}
 
+	if h.MaxPublicKeys > 0 && len(req.PublicKeys) > h.MaxPublicKeys {
+		errStr := fmt.Sprintf("too many public keys: maximum is %d, got %d", h.MaxPublicKeys, len(req.PublicKeys))
+		return httperror.BadRequest(errStr, errors.New(errStr))
+	}
+
 	deduplicatedPublicKeys := set.NewSet[string](req.PublicKeys...)
 
-	ledgerKeyAccountKeys, ledgerKeyAccountKeysError := getLedgerKeyAccountKeys(deduplicatedPublicKeys.ToSlice())
+	ledgerKeyAccountKeys, ledgerKeyAccountKeysError := getLedgerKeyAccountKeys(contextWithTimeout, deduplicatedPublicKeys.ToSlice())
 	if ledgerKeyAccountKeysError.ErrorMessage != "" {
 		ledgerKeyAccountError = ledgerKeyAccountKeysError
 	}

--- a/internal/api/handlers/ledger_key_accounts_test.go
+++ b/internal/api/handlers/ledger_key_accounts_test.go
@@ -28,7 +28,7 @@ func TestGetLedgerKeyAccounts(t *testing.T) {
 			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
 		}
 
-		handler := NewLedgerKeyAccountHandler(mockRPC)
+		handler := NewLedgerKeyAccountHandler(mockRPC, 100)
 
 		body := `{
 			"public_keys": [
@@ -80,7 +80,7 @@ func TestGetLedgerKeyAccounts(t *testing.T) {
 			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
 		}
 
-		handler := NewLedgerKeyAccountHandler(mockRPC)
+		handler := NewLedgerKeyAccountHandler(mockRPC, 100)
 
 		body := `{
 			"public_keys": [
@@ -151,7 +151,7 @@ func TestGetLedgerKeyAccounts(t *testing.T) {
 			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
 		}
 
-		handler := NewLedgerKeyAccountHandler(mockRPC)
+		handler := NewLedgerKeyAccountHandler(mockRPC, 100)
 
 		body := `{
 			"public_keys": [
@@ -210,7 +210,7 @@ func TestGetLedgerKeyAccounts(t *testing.T) {
 			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
 		}
 
-		handler := NewLedgerKeyAccountHandler(mockRPC)
+		handler := NewLedgerKeyAccountHandler(mockRPC, 100)
 
 		body := `{
 			"public_keys": [
@@ -264,7 +264,7 @@ func TestGetLedgerKeyAccounts(t *testing.T) {
 			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
 		}
 
-		handler := NewLedgerKeyAccountHandler(mockRPC)
+		handler := NewLedgerKeyAccountHandler(mockRPC, 100)
 
 		body := `{
 			"public_keys": [
@@ -315,7 +315,7 @@ func TestGetLedgerKeyAccounts(t *testing.T) {
 			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
 		}
 
-		handler := NewLedgerKeyAccountHandler(mockRPC)
+		handler := NewLedgerKeyAccountHandler(mockRPC, 100)
 
 		body := `{
 			"public_keys": [
@@ -344,7 +344,7 @@ func TestGetLedgerKeyAccounts(t *testing.T) {
 			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
 		}
 
-		handler := NewLedgerKeyAccountHandler(mockRPC)
+		handler := NewLedgerKeyAccountHandler(mockRPC, 100)
 
 		body := ``
 
@@ -354,5 +354,134 @@ func TestGetLedgerKeyAccounts(t *testing.T) {
 		err := handler.GetLedgerKeyAccounts(rr, req)
 		require.Error(t, err)
 		assert.EqualError(t, err, "Invalid request - public keys are required: invalid JSON: EOF")
+	})
+
+	t.Run("should reject requests exceeding MaxPublicKeys with 400", func(t *testing.T) {
+		t.Parallel()
+
+		mockRPC := &utils.MockRPCService{
+			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
+		}
+
+		const maxKeys = 3
+		handler := NewLedgerKeyAccountHandler(mockRPC, maxKeys)
+
+		keys := []string{
+			"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+			"GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+			"GAWYJTG6RQFXMSOEF7LHUOSDOUQLAHNQGJO5QULS6FTHCR3HCPZDXJKX",
+			"GAWYJTG6RQFXMSOEF7LHUOSDOUQLAHNQGJO5QULS6FTHCR3HCPZDXJKY",
+		}
+		bodyBytes, err := json.Marshal(LedgerKeyAccountRequest{PublicKeys: keys})
+		require.NoError(t, err)
+
+		req, _ := http.NewRequest("POST", "/api/v1/ledger-key/accounts?network=PUBLIC", strings.NewReader(string(bodyBytes)))
+		rr := httptest.NewRecorder()
+
+		err = handler.GetLedgerKeyAccounts(rr, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too many public keys")
+		assert.Contains(t, err.Error(), "maximum is 3")
+		assert.Contains(t, err.Error(), "got 4")
+	})
+
+	t.Run("should allow requests at exactly MaxPublicKeys", func(t *testing.T) {
+		t.Parallel()
+
+		mockRPC := &utils.MockRPCService{
+			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
+		}
+
+		handler := NewLedgerKeyAccountHandler(mockRPC, 2)
+
+		body := `{
+			"public_keys": [
+				"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+				"GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+			]
+		}`
+
+		req, _ := http.NewRequest("POST", "/api/v1/ledger-key/accounts?network=PUBLIC", strings.NewReader(body))
+		rr := httptest.NewRecorder()
+
+		err := handler.GetLedgerKeyAccounts(rr, req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("should allow unlimited keys when MaxPublicKeys is 0", func(t *testing.T) {
+		t.Parallel()
+
+		mockRPC := &utils.MockRPCService{
+			GetLedgerEntryOverride: utils.MockLedgerEntryData.LedgerEntry,
+		}
+
+		handler := NewLedgerKeyAccountHandler(mockRPC, 0)
+
+		body := `{
+			"public_keys": [
+				"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+				"GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+			]
+		}`
+
+		req, _ := http.NewRequest("POST", "/api/v1/ledger-key/accounts?network=PUBLIC", strings.NewReader(body))
+		rr := httptest.NewRecorder()
+
+		err := handler.GetLedgerKeyAccounts(rr, req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestProcessLedgerKeyAccountsEntries(t *testing.T) {
+	t.Parallel()
+
+	entries := []types.LedgerEntryMap{
+		{Account: types.AccountInfo{AccountId: "GA", Balance: "1"}},
+		{Account: types.AccountInfo{AccountId: "GB", Balance: "2"}},
+		{Account: types.AccountInfo{AccountId: "GC", Balance: "3"}},
+	}
+
+	t.Run("returns matches for keys that correspond to ledger entries", func(t *testing.T) {
+		t.Parallel()
+		result, errOut := processLedgerKeyAccountsEntries([]string{"GA", "GC"}, entries)
+		assert.Equal(t, "", errOut.ErrorMessage)
+		assert.Equal(t, LedgerKeyAccountMap{
+			"GA": {AccountId: "GA", Balance: "1"},
+			"GC": {AccountId: "GC", Balance: "3"},
+		}, result)
+	})
+
+	t.Run("omits keys that do not match any entry", func(t *testing.T) {
+		t.Parallel()
+		result, _ := processLedgerKeyAccountsEntries([]string{"GA", "G_MISSING"}, entries)
+		assert.Contains(t, result, "GA")
+		assert.NotContains(t, result, "G_MISSING")
+	})
+
+	t.Run("returns empty map when no entries are provided", func(t *testing.T) {
+		t.Parallel()
+		result, _ := processLedgerKeyAccountsEntries([]string{"GA", "GB"}, nil)
+		assert.Empty(t, result)
+	})
+
+	t.Run("matches old nested-loop behavior for mixed input", func(t *testing.T) {
+		t.Parallel()
+		keys := []string{"GA", "GB", "GC", "G_MISSING", "GA"}
+
+		newImpl, _ := processLedgerKeyAccountsEntries(keys, entries)
+
+		oldImpl := LedgerKeyAccountMap{}
+		for _, publicKey := range keys {
+			for _, entry := range entries {
+				if entry.Account.AccountId == publicKey {
+					oldImpl[publicKey] = entry.Account
+					break
+				}
+			}
+		}
+
+		assert.Equal(t, oldImpl, newImpl)
 	})
 }

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -100,7 +100,7 @@ func (s *ApiServer) initHandlers() *http.ServeMux {
 	collectiblesHandler := handlers.NewCollectiblesHandler(s.rpcService, s.cfg.AppConfig.MeridianPayTreasureHuntAddress, s.cfg.AppConfig.MeridianPayTreasurePoapAddress, s.cfg.AppConfig.MeridianPayStellarHouseAddress, s.cfg.RpcConfig.MaxConcurrentRPCCalls)
 	mux.HandleFunc("POST /api/v1/collectibles", handlers.CustomHandler(collectiblesHandler.GetCollectibles))
 
-	ledgerKeyAccountsHandler := handlers.NewLedgerKeyAccountHandler(s.rpcService)
+	ledgerKeyAccountsHandler := handlers.NewLedgerKeyAccountHandler(s.rpcService, s.cfg.AppConfig.MaxLedgerKeyAddresses)
 	mux.HandleFunc("POST /api/v1/ledger-key/accounts", handlers.CustomHandler(ledgerKeyAccountsHandler.GetLedgerKeyAccounts))
 
 	featureFlagsHandler := handlers.NewFeatureFlagsHandler()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type AppConfig struct {
 	MeridianPayStellarHouseAddress string
 	MaxRequestBodySize             int64
 	MaxBalanceAddresses            int
+	MaxLedgerKeyAddresses          int
 }
 
 type RPCConfig struct {

--- a/internal/services/rpc.go
+++ b/internal/services/rpc.go
@@ -21,10 +21,9 @@ import (
 const (
 	serviceName = "rpc"
 
-	// MaxLedgerEntryKeys caps the number of keys forwarded to the upstream Stellar RPC in a
-	// single GetLedgerEntries call. Independent of any handler-level cap: if a future caller
-	// passes an unbounded slice this acts as a last-line defense against upstream abuse and
-	// local CPU/memory blow-up during response decoding.
+	// MaxLedgerEntryKeys mirrors stellar-rpc's getLedgerEntriesMaxKeys: upstream rejects
+	// getLedgerEntries calls with more than 200 keys. Enforced here so a future caller that
+	// bypasses handler-level caps still fails fast locally instead of round-tripping to RPC.
 	MaxLedgerEntryKeys = 200
 )
 

--- a/internal/services/rpc.go
+++ b/internal/services/rpc.go
@@ -20,6 +20,12 @@ import (
 
 const (
 	serviceName = "rpc"
+
+	// MaxLedgerEntryKeys caps the number of keys forwarded to the upstream Stellar RPC in a
+	// single GetLedgerEntries call. Independent of any handler-level cap: if a future caller
+	// passes an unbounded slice this acts as a last-line defense against upstream abuse and
+	// local CPU/memory blow-up during response decoding.
+	MaxLedgerEntryKeys = 200
 )
 
 type rpcService struct {
@@ -195,6 +201,10 @@ func (r *rpcService) GetLedgerEntries(ctx context.Context, keys []string, networ
 	defer func() {
 		metrics.Record(r.svcMetrics, serviceName, "GetLedgerEntries", network, time.Since(start).Seconds(), err)
 	}()
+
+	if len(keys) > MaxLedgerEntryKeys {
+		return nil, fmt.Errorf("too many ledger entry keys: maximum is %d, got %d", MaxLedgerEntryKeys, len(keys))
+	}
 
 	networkClient := r.configureNetworkClient(network)
 	response, err := networkClient.GetLedgerEntries(ctx, rpc.GetLedgerEntriesRequest{

--- a/internal/services/rpc_test.go
+++ b/internal/services/rpc_test.go
@@ -574,4 +574,25 @@ func TestNewRPCService_GetLedgerEntry(t *testing.T) {
 		assert.Nil(t, response)
 		assert.Equal(t, "failed to get ledger entries: [-32603] Post \"http://localhost:8002\": dial tcp [::1]:8002: connect: connection refused", err.Error())
 	})
+
+	t.Run("rejects requests exceeding MaxLedgerEntryKeys without calling upstream", func(t *testing.T) {
+		called := false
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+		}))
+		defer upstream.Close()
+
+		service := NewRPCService(upstream.URL, "http://localhost:8001", "http://localhost:8002", nil)
+		keys := make([]string, MaxLedgerEntryKeys+1)
+		for i := range keys {
+			keys[i] = "k"
+		}
+
+		response, err := service.GetLedgerEntries(context.Background(), keys, types.PUBLIC)
+
+		assert.Nil(t, response)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too many ledger entry keys")
+		assert.False(t, called, "upstream RPC must not be called when key count exceeds cap")
+	})
 }

--- a/internal/services/rpc_test.go
+++ b/internal/services/rpc_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stellar/go-stellar-sdk/keypair"
@@ -576,9 +577,9 @@ func TestNewRPCService_GetLedgerEntry(t *testing.T) {
 	})
 
 	t.Run("rejects requests exceeding MaxLedgerEntryKeys without calling upstream", func(t *testing.T) {
-		called := false
+		var called atomic.Bool
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			called = true
+			called.Store(true)
 		}))
 		defer upstream.Close()
 
@@ -593,6 +594,6 @@ func TestNewRPCService_GetLedgerEntry(t *testing.T) {
 		assert.Nil(t, response)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "too many ledger entry keys")
-		assert.False(t, called, "upstream RPC must not be called when key count exceeds cap")
+		assert.False(t, called.Load(), "upstream RPC must not be called when key count exceeds cap")
 	})
 }


### PR DESCRIPTION
What
- Cap `public_keys` per request at MaxLedgerKeyAddresses (--max-ledger-key-addresses, default 100) before any decoding or RPC work, mirroring the existing MaxBalanceAddresses pattern.
- Replace the nested loop in `processLedgerKeyAccountsEntries` with an O(N+M) map lookup built from the RPC response.
- Honor `ctx.Err()` inside `getLedgerKeyAccountKeys` so cancellation actually stops the XDR decode loop.
- Add a defensive MaxLedgerEntryKeys (200) guard in `RpcService.GetLedgerEntries` so no future caller can forward an unbounded key slice to the upstream Stellar RPC.

Tests cover over-limit rejection, at-limit success, unlimited mode (max = 0), parity of the new map-based lookup with the old nested loop, and the upstream RPC cap.

Why
`processLedgerKeyAccountsEntries` scanned the RPC entries list once per submitted public key (O(N*M)), and the only input bound was a 1 MB body limit that comfortably fits ~15k keys. A single request could peg a core for ~12 s, and the 5s handler context was never consulted by the loop.