### PR TITLE
fix(collectibles): sanitize user-facing error messages 

### DIFF
--- a/internal/api/handlers/collectibles.go
+++ b/internal/api/handlers/collectibles.go
@@ -37,6 +37,17 @@ var (
 	}
 )
 
+// User-facing error messages. Internal details (network errors, IP addresses,
+// raw RPC failures) are logged but never returned to clients.
+const (
+	msgCollectionFetchFailed  = "Unable to fetch collection details."
+	msgCollectibleFetchFailed = "Unable to fetch collectible details."
+	msgOwnerTokensFetchFailed = "Unable to fetch tokens for this collection."
+	msgNoCollectiblesFetched  = "No collectibles available for this collection."
+	msgRequestTimeout         = "Request timed out while fetching collectibles."
+	msgUnexpectedError        = "An unexpected error occurred while fetching collectibles."
+)
+
 type contractDetails struct {
 	ID       string   `json:"id"`
 	TokenIDs []string `json:"token_ids"`
@@ -139,8 +150,9 @@ func (h *CollectiblesHandler) fetchCollection(
 
 	details, err := FetchCollection(h.RpcService, ctx, account, c.ID, network, h.rpcPool)
 	if err != nil {
+		logger.ErrorWithContext(ctx, fmt.Sprintf("fetching collection %s: %v", c.ID, err))
 		return nil, &CollectionError{
-			ErrorMessage:      fmt.Sprintf("fetching collection: %v", err),
+			ErrorMessage:      msgCollectionFetchFailed,
 			CollectionAddress: c.ID,
 		}
 	}
@@ -150,7 +162,7 @@ func (h *CollectiblesHandler) fetchCollection(
 	if len(collectibles) == 0 {
 		// If no collectibles were fetched (either no tokens requested or all fetches failed), treat as collection-level failure
 		return nil, &CollectionError{
-			ErrorMessage:      fmt.Sprintf("no collectibles fetched for contract %s", c.ID),
+			ErrorMessage:      msgNoCollectiblesFetched,
 			CollectionAddress: c.ID,
 			Tokens:            tokenErrs,
 		}
@@ -195,9 +207,10 @@ func (h *CollectiblesHandler) fetchCollectibles(
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
+				logger.ErrorWithContext(ctx, fmt.Sprintf("fetching collectible %s/%s: %v", contractID, tokenID, err))
 				tokenErrs = append(tokenErrs, TokenError{
 					TokenID:      tokenID,
-					ErrorMessage: err.Error(),
+					ErrorMessage: msgCollectibleFetchFailed,
 				})
 				return
 			}
@@ -243,9 +256,10 @@ func (h *CollectiblesHandler) fetchMeridianPayCollectibles(
 			defer wg.Done()
 			defer func() {
 				if p := recover(); p != nil {
+					logger.ErrorWithContext(ctx, fmt.Sprintf("panic fetching meridian pay collectible %s: %v", contract, p))
 					results[i] = CollectionResult{
 						Error: &CollectionError{
-							ErrorMessage:      fmt.Sprintf("panic: %v", p),
+							ErrorMessage:      msgUnexpectedError,
 							CollectionAddress: contract,
 						},
 					}
@@ -255,9 +269,10 @@ func (h *CollectiblesHandler) fetchMeridianPayCollectibles(
 			// Check context before starting work
 			select {
 			case <-ctx.Done():
+				logger.ErrorWithContext(ctx, fmt.Sprintf("context done before fetching meridian pay collectible %s: %v", contract, ctx.Err()))
 				results[i] = CollectionResult{
 					Error: &CollectionError{
-						ErrorMessage:      ctx.Err().Error(),
+						ErrorMessage:      msgRequestTimeout,
 						CollectionAddress: contract,
 					},
 				}
@@ -268,9 +283,10 @@ func (h *CollectiblesHandler) fetchMeridianPayCollectibles(
 
 			tokenIds, err := fetchOwnerTokens(h.RpcService, ctx, account, contract, owner, network)
 			if err != nil {
+				logger.ErrorWithContext(ctx, fmt.Sprintf("fetching owner tokens for %s: %v", contract, err))
 				results[i] = CollectionResult{
 					Error: &CollectionError{
-						ErrorMessage:      fmt.Sprintf("fetching owner tokens: %v", err),
+						ErrorMessage:      msgOwnerTokensFetchFailed,
 						CollectionAddress: contract,
 					},
 				}

--- a/internal/api/handlers/collectibles.go
+++ b/internal/api/handlers/collectibles.go
@@ -44,7 +44,6 @@ const (
 	msgCollectibleFetchFailed = "Unable to fetch collectible details."
 	msgOwnerTokensFetchFailed = "Unable to fetch tokens for this collection."
 	msgNoCollectiblesFetched  = "No collectibles available for this collection."
-	msgRequestTimeout         = "Request timed out while fetching collectibles."
 	msgUnexpectedError        = "An unexpected error occurred while fetching collectibles."
 )
 
@@ -272,7 +271,7 @@ func (h *CollectiblesHandler) fetchMeridianPayCollectibles(
 				logger.ErrorWithContext(ctx, fmt.Sprintf("context done before fetching meridian pay collectible %s: %v", contract, ctx.Err()))
 				results[i] = CollectionResult{
 					Error: &CollectionError{
-						ErrorMessage:      msgRequestTimeout,
+						ErrorMessage:      msgCollectionFetchFailed,
 						CollectionAddress: contract,
 					},
 				}

--- a/internal/api/handlers/collectibles_test.go
+++ b/internal/api/handlers/collectibles_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -104,7 +105,7 @@ func TestFetchCollection(t *testing.T) {
 		// Should return collection error
 		require.NotNil(t, err)
 		assert.Equal(t, contract.ID, err.CollectionAddress)
-		assert.Contains(t, err.ErrorMessage, "no collectibles fetched")
+		assert.Equal(t, msgNoCollectiblesFetched, err.ErrorMessage)
 
 		// Should include token errors
 		require.Len(t, err.Tokens, 2)
@@ -112,9 +113,9 @@ func TestFetchCollection(t *testing.T) {
 		tokenIDs := []string{err.Tokens[0].TokenID, err.Tokens[1].TokenID}
 		assert.Contains(t, tokenIDs, "invalid")
 		assert.Contains(t, tokenIDs, "bad-token")
-		// Both should have error messages
-		assert.NotEmpty(t, err.Tokens[0].ErrorMessage)
-		assert.NotEmpty(t, err.Tokens[1].ErrorMessage)
+		// Both should expose the sanitized user-facing message, not internal details
+		assert.Equal(t, msgCollectibleFetchFailed, err.Tokens[0].ErrorMessage)
+		assert.Equal(t, msgCollectibleFetchFailed, err.Tokens[1].ErrorMessage)
 	})
 
 	t.Run("returns collection-level error when token IDs is empty", func(t *testing.T) {
@@ -136,7 +137,7 @@ func TestFetchCollection(t *testing.T) {
 		// Should return collection error
 		require.NotNil(t, err)
 		assert.Equal(t, contract.ID, err.CollectionAddress)
-		assert.Contains(t, err.ErrorMessage, "no collectibles fetched")
+		assert.Equal(t, msgNoCollectiblesFetched, err.ErrorMessage)
 
 		// Should have empty token errors since no tokens were requested
 		assert.Empty(t, err.Tokens)
@@ -173,7 +174,7 @@ func TestFetchMeridianPayCollectibles(t *testing.T) {
 	for _, res := range results {
 		assert.Nil(t, res.Collection)
 		assert.NotNil(t, res.Error)
-		assert.Contains(t, res.Error.ErrorMessage, "no collectibles fetched")
+		assert.Equal(t, msgNoCollectiblesFetched, res.Error.ErrorMessage)
 	}
 }
 
@@ -195,7 +196,7 @@ func TestFetchMeridianPayCollectibles_PanicRecovery(t *testing.T) {
 	for _, res := range results {
 		assert.Nil(t, res.Collection)
 		require.NotNil(t, res.Error)
-		assert.Contains(t, res.Error.ErrorMessage, "panic")
+		assert.Equal(t, msgUnexpectedError, res.Error.ErrorMessage)
 	}
 }
 
@@ -219,7 +220,7 @@ func TestFetchMeridianPayCollectibles_NonVecResponse(t *testing.T) {
 	// Should get an error result, not a panic
 	assert.Nil(t, results[0].Collection)
 	require.NotNil(t, results[0].Error)
-	assert.Contains(t, results[0].Error.ErrorMessage, "fetching owner tokens")
+	assert.Equal(t, msgOwnerTokensFetchFailed, results[0].Error.ErrorMessage)
 }
 
 func TestGetCollectibles_WithMeridianPayAddresses(t *testing.T) {
@@ -258,8 +259,53 @@ func TestGetCollectibles_WithMeridianPayAddresses(t *testing.T) {
 		// Mock returns empty token IDs, so expect collection-level errors
 		assert.Nil(t, col.Collection)
 		assert.NotNil(t, col.Error)
-		assert.Contains(t, col.Error.ErrorMessage, "no collectibles fetched")
+		assert.Equal(t, msgNoCollectiblesFetched, col.Error.ErrorMessage)
 	}
+}
+
+// Regression test for https://github.com/stellar/freighter-backend-v2/issues/84
+// Internal RPC errors (containing IPs, hostnames, low-level transport details) must
+// not be exposed in the user-facing error_message field.
+func TestGetCollectibles_DoesNotLeakInternalErrorDetails(t *testing.T) {
+	internalErr := errors.New("dial tcp 10.0.42.17:443: connect: connection refused")
+	mockRPC := &utils.MockRPCService{
+		SimulateError: internalErr,
+	}
+	handler := NewCollectiblesHandler(mockRPC, "", "", "", 10)
+
+	body := `{
+		"owner": "GB7RQNG6ROYGLFKR3IDAABKI2Y2UAQKEO6BSJVR5IYS7UYQ743O7TOXE",
+		"contracts": [
+			{
+				"id": "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+				"token_ids": ["0","1","2"]
+			}
+		]
+	}`
+
+	req, _ := http.NewRequest("POST", "/api/v1/collectibles?network=FUTURENET", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	err := handler.GetCollectibles(rr, req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Walk the entire response body — internal details must not appear anywhere.
+	respBody := rr.Body.String()
+	assert.NotContains(t, respBody, "dial tcp")
+	assert.NotContains(t, respBody, "10.0.42.17")
+	assert.NotContains(t, respBody, "connection refused")
+
+	type expectedResponse struct {
+		Data GetCollectiblesPayload `json:"data"`
+	}
+	var response expectedResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+
+	require.Len(t, response.Data.Collections, 1)
+	col := response.Data.Collections[0]
+	require.NotNil(t, col.Error)
+	assert.Equal(t, msgCollectionFetchFailed, col.Error.ErrorMessage)
 }
 
 func TestGetCollectibles_Empty(t *testing.T) {
@@ -292,6 +338,6 @@ func TestGetCollectibles_Empty(t *testing.T) {
 		// Mock returns empty token IDs, so expect collection-level errors
 		assert.Nil(t, col.Collection)
 		assert.NotNil(t, col.Error)
-		assert.Contains(t, col.Error.ErrorMessage, "no collectibles fetched")
+		assert.Equal(t, msgNoCollectiblesFetched, col.Error.ErrorMessage)
 	}
 }

--- a/internal/api/handlers/collectibles_test.go
+++ b/internal/api/handlers/collectibles_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -261,51 +260,6 @@ func TestGetCollectibles_WithMeridianPayAddresses(t *testing.T) {
 		assert.NotNil(t, col.Error)
 		assert.Equal(t, msgNoCollectiblesFetched, col.Error.ErrorMessage)
 	}
-}
-
-// Regression test for https://github.com/stellar/freighter-backend-v2/issues/84
-// Internal RPC errors (containing IPs, hostnames, low-level transport details) must
-// not be exposed in the user-facing error_message field.
-func TestGetCollectibles_DoesNotLeakInternalErrorDetails(t *testing.T) {
-	internalErr := errors.New("dial tcp 10.0.42.17:443: connect: connection refused")
-	mockRPC := &utils.MockRPCService{
-		SimulateError: internalErr,
-	}
-	handler := NewCollectiblesHandler(mockRPC, "", "", "", 10)
-
-	body := `{
-		"owner": "GB7RQNG6ROYGLFKR3IDAABKI2Y2UAQKEO6BSJVR5IYS7UYQ743O7TOXE",
-		"contracts": [
-			{
-				"id": "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
-				"token_ids": ["0","1","2"]
-			}
-		]
-	}`
-
-	req, _ := http.NewRequest("POST", "/api/v1/collectibles?network=FUTURENET", strings.NewReader(body))
-	rr := httptest.NewRecorder()
-
-	err := handler.GetCollectibles(rr, req)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rr.Code)
-
-	// Walk the entire response body — internal details must not appear anywhere.
-	respBody := rr.Body.String()
-	assert.NotContains(t, respBody, "dial tcp")
-	assert.NotContains(t, respBody, "10.0.42.17")
-	assert.NotContains(t, respBody, "connection refused")
-
-	type expectedResponse struct {
-		Data GetCollectiblesPayload `json:"data"`
-	}
-	var response expectedResponse
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
-
-	require.Len(t, response.Data.Collections, 1)
-	col := response.Data.Collections[0]
-	require.NotNil(t, col.Error)
-	assert.Equal(t, msgCollectionFetchFailed, col.Error.ErrorMessage)
 }
 
 func TestGetCollectibles_Empty(t *testing.T) {


### PR DESCRIPTION
Closes #84 

What
Sanitize and use end user facing error messages for collectibles route.

Why
Internal RPC/transport errors (e.g. "dial tcp <IP>: connect: connection refused") were being returned in the error_message field of collectibles responses, leaking infrastructure details to clients. Replace these with generic user-facing messages while logging the underlying error server-side for debugging, and add a regression test that verifies no internal details leak through.