### PR TITLE
fix(metrics): serve /metrics on a separate internal port

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -42,6 +42,8 @@ func (s *ServeCmd) Command() *cobra.Command {
 	// App Config
 	cmd.Flags().StringVar(&s.Cfg.AppConfig.FreighterBackendHost, "freighter-backend-host", "localhost", "The host of the freighter backend server")
 	cmd.Flags().IntVar(&s.Cfg.AppConfig.FreighterBackendPort, "freighter-backend-port", 3002, "The port of the freighter backend server")
+	cmd.Flags().StringVar(&s.Cfg.AppConfig.MetricsHost, "metrics-host", "localhost", "The host of the internal metrics server (Prometheus /metrics)")
+	cmd.Flags().IntVar(&s.Cfg.AppConfig.MetricsPort, "metrics-port", 9090, "The port of the internal metrics server (Prometheus /metrics)")
 	cmd.Flags().StringVar(&s.Cfg.AppConfig.Mode, "mode", "development", "The mode of the server")
 	cmd.Flags().StringVar(&s.Cfg.AppConfig.SentryKey, "sentry-key", "", "The Sentry key")
 	cmd.Flags().StringVar(&s.Cfg.AppConfig.ProtocolsConfigPath, "protocols-config-path", "/app/config/protocols.json", "The path to the protocols config file while lists all supported protocols in Freighter")

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.37.0
+	golang.org/x/sync v0.18.0
 )
 
 require (
@@ -98,7 +99,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect

--- a/internal/api/middleware/metrics.go
+++ b/internal/api/middleware/metrics.go
@@ -1,5 +1,5 @@
 // ABOUTME: HTTP middleware that records Prometheus metrics for each request.
-// ABOUTME: Reads final status from BufferedResponseWriter after handler completes, skips /metrics endpoint.
+// ABOUTME: Reads final status from BufferedResponseWriter after handler completes.
 package middleware
 
 import (
@@ -14,11 +14,6 @@ import (
 func Metrics(h *metrics.HTTP) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/metrics" {
-				next.ServeHTTP(w, r)
-				return
-			}
-
 			h.InFlightRequests.Inc()
 			defer h.InFlightRequests.Dec()
 

--- a/internal/api/middleware/metrics_test.go
+++ b/internal/api/middleware/metrics_test.go
@@ -1,5 +1,5 @@
 // ABOUTME: Unit tests for the Prometheus metrics middleware.
-// ABOUTME: Verifies request counting, duration recording, in-flight gauge, /metrics exclusion, and unknown handler label.
+// ABOUTME: Verifies request counting, duration recording, in-flight gauge, and unknown handler label.
 package middleware
 
 import (
@@ -61,28 +61,6 @@ func TestMetricsMiddleware_RecordsDuration(t *testing.T) {
 
 	count := testutil.CollectAndCount(reg, "freighter_http_request_duration_seconds")
 	assert.Equal(t, 1, count)
-}
-
-func TestMetricsMiddleware_SkipsMetricsEndpoint(t *testing.T) {
-	h, _ := newTestHTTPMetrics(t)
-
-	called := false
-	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusOK)
-	})
-
-	mw := Metrics(h)(inner)
-
-	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
-	rec := httptest.NewRecorder()
-	mw.ServeHTTP(rec, req)
-
-	assert.True(t, called, "inner handler should be called")
-
-	// No metrics should be recorded for /metrics itself
-	count := testutil.ToFloat64(h.RequestsTotal.WithLabelValues("unknown", "GET", "200"))
-	assert.Equal(t, float64(0), count)
 }
 
 func TestMetricsMiddleware_InFlightGauge(t *testing.T) {

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/handlers"
 	"github.com/stellar/freighter-backend-v2/internal/api/middleware"
@@ -57,8 +58,7 @@ func (s *ApiServer) Start() error {
 
 	apiHandler := s.initMiddleware(s.initHandlers())
 	metricsHandler := middleware.Chain(s.initMetricsHandler(), middleware.Recover())
-	s.startServers(apiHandler, metricsHandler)
-	return nil
+	return s.startServers(apiHandler, metricsHandler)
 }
 
 func (s *ApiServer) initServices() error {
@@ -132,7 +132,7 @@ func (s *ApiServer) initMiddleware(mux *http.ServeMux) http.Handler {
 	return handler
 }
 
-func (s *ApiServer) startServers(apiHandler http.Handler, metricsHandler http.Handler) {
+func (s *ApiServer) startServers(apiHandler http.Handler, metricsHandler http.Handler) error {
 	apiServer := &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", s.cfg.AppConfig.FreighterBackendHost, s.cfg.AppConfig.FreighterBackendPort),
 		Handler:      apiHandler,
@@ -148,33 +148,47 @@ func (s *ApiServer) startServers(apiHandler http.Handler, metricsHandler http.Ha
 		IdleTimeout:  DefaultIdleTimeout,
 	}
 
-	go func() {
+	// errgroup: if either ListenAndServe returns an unexpected error, ctx is
+	// canceled so we tear down the surviving server and surface the failure.
+	g, ctx := errgroup.WithContext(context.Background())
+	g.Go(func() error {
 		logger.Info("Starting API server", "address", apiServer.Addr)
 		if err := apiServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Error("API server error", "error", err)
+			return fmt.Errorf("api server: %w", err)
 		}
-	}()
-	go func() {
+		return nil
+	})
+	g.Go(func() error {
 		logger.Info("Starting metrics server", "address", metricsServer.Addr)
 		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Error("Metrics server error", "error", err)
+			return fmt.Errorf("metrics server: %w", err)
 		}
-	}()
+		return nil
+	})
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
 
-	logger.Info("Shutting down servers...")
-	ctx, cancel := context.WithTimeout(context.Background(), ServerShutdownTimeout)
+	select {
+	case <-quit:
+		logger.Info("Shutting down servers...")
+	case <-ctx.Done():
+		logger.Error("Server exited unexpectedly; shutting down siblings")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), ServerShutdownTimeout)
 	defer cancel()
 
-	if err := apiServer.Shutdown(ctx); err != nil {
+	if err := apiServer.Shutdown(shutdownCtx); err != nil {
 		logger.Error("API server forced to shutdown", "error", err)
 	}
-	if err := metricsServer.Shutdown(ctx); err != nil {
+	if err := metricsServer.Shutdown(shutdownCtx); err != nil {
 		logger.Error("Metrics server forced to shutdown", "error", err)
 	}
 
+	if err := g.Wait(); err != nil {
+		return err
+	}
 	logger.Info("Servers gracefully stopped")
+	return nil
 }

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -55,9 +55,9 @@ func (s *ApiServer) Start() error {
 		return err
 	}
 
-	mux := s.initHandlers()
-	handler := s.initMiddleware(mux)
-	s.startServer(handler)
+	apiHandler := s.initMiddleware(s.initHandlers())
+	metricsHandler := middleware.Chain(s.initMetricsHandler(), middleware.Recover())
+	s.startServers(apiHandler, metricsHandler)
 	return nil
 }
 
@@ -109,8 +109,12 @@ func (s *ApiServer) initHandlers() *http.ServeMux {
 	accountBalancesHandler := handlers.NewAccountBalancesHandler(s.walletBackendService, s.cfg.AppConfig.MaxBalanceAddresses)
 	mux.HandleFunc("POST /api/v1/account-balances", handlers.CustomHandler(accountBalancesHandler.GetAccountBalances))
 
-	mux.Handle("GET /metrics", promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{Registry: s.registry}))
+	return mux
+}
 
+func (s *ApiServer) initMetricsHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("GET /metrics", promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{Registry: s.registry}))
 	return mux
 }
 
@@ -128,36 +132,49 @@ func (s *ApiServer) initMiddleware(mux *http.ServeMux) http.Handler {
 	return handler
 }
 
-func (s *ApiServer) startServer(handler http.Handler) {
-	server := &http.Server{
+func (s *ApiServer) startServers(apiHandler http.Handler, metricsHandler http.Handler) {
+	apiServer := &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", s.cfg.AppConfig.FreighterBackendHost, s.cfg.AppConfig.FreighterBackendPort),
-		Handler:      handler,
+		Handler:      apiHandler,
+		ReadTimeout:  DefaultReadTimeout,
+		WriteTimeout: DefaultWriteTimeout,
+		IdleTimeout:  DefaultIdleTimeout,
+	}
+	metricsServer := &http.Server{
+		Addr:         fmt.Sprintf("%s:%d", s.cfg.AppConfig.MetricsHost, s.cfg.AppConfig.MetricsPort),
+		Handler:      metricsHandler,
 		ReadTimeout:  DefaultReadTimeout,
 		WriteTimeout: DefaultWriteTimeout,
 		IdleTimeout:  DefaultIdleTimeout,
 	}
 
-	// Start the server in a goroutine
 	go func() {
-		logger.Info("Starting HTTP server", "address", server.Addr)
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Error("HTTP server error", "error", err)
+		logger.Info("Starting API server", "address", apiServer.Addr)
+		if err := apiServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("API server error", "error", err)
+		}
+	}()
+	go func() {
+		logger.Info("Starting metrics server", "address", metricsServer.Addr)
+		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("Metrics server error", "error", err)
 		}
 	}()
 
-	// Wait for termination signal
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 
-	// Graceful shutdown
-	logger.Info("Shutting down server...")
+	logger.Info("Shutting down servers...")
 	ctx, cancel := context.WithTimeout(context.Background(), ServerShutdownTimeout)
 	defer cancel()
 
-	if err := server.Shutdown(ctx); err != nil {
-		logger.Error("Server forced to shutdown", "error", err)
+	if err := apiServer.Shutdown(ctx); err != nil {
+		logger.Error("API server forced to shutdown", "error", err)
+	}
+	if err := metricsServer.Shutdown(ctx); err != nil {
+		logger.Error("Metrics server forced to shutdown", "error", err)
 	}
 
-	logger.Info("Server gracefully stopped")
+	logger.Info("Servers gracefully stopped")
 }

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -41,6 +43,46 @@ func TestApiServer_initHandlers(t *testing.T) {
 	assert.Contains(t, pattern, "/api/v1/ping")
 	healthHandler := handlers.NewHealthHandler()
 	assert.IsType(t, handlers.CustomHandler(healthHandler.CheckHealth), handler, "returned handler should be the health check handler")
+}
+
+func TestApiServer_initHandlers_DoesNotServeMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	cfg := &config.Config{AppConfig: config.AppConfig{ProtocolsConfigPath: "testdata/protocols.json"}}
+	s := &ApiServer{cfg: cfg, registry: reg}
+	mux := s.initHandlers()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code, "/metrics must not be reachable on the public API mux")
+}
+
+func TestApiServer_initMetricsHandler(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(collectors.NewGoCollector())
+	s := &ApiServer{cfg: &config.Config{}, registry: reg}
+
+	handler := s.initMetricsHandler()
+	require.NotNil(t, handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "# HELP go_")
+}
+
+func TestApiServer_initMetricsHandler_RejectsOtherPaths(t *testing.T) {
+	s := &ApiServer{cfg: &config.Config{}, registry: prometheus.NewRegistry()}
+	handler := s.initMetricsHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code, "metrics server must only expose /metrics")
 }
 
 func TestApiServer_initMiddleware(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ type Config struct {
 type AppConfig struct {
 	FreighterBackendHost           string
 	FreighterBackendPort           int
+	MetricsHost                    string
+	MetricsPort                    int
 	Mode                           string
 	SentryKey                      string
 	ProtocolsConfigPath            string

--- a/internal/integrationtests/infrastructure/containers.go
+++ b/internal/integrationtests/infrastructure/containers.go
@@ -27,6 +27,8 @@ const (
 	FreighterContainerName  = "freighter"
 	FreighterContainerHost  = "0.0.0.0"
 	FreighterContainerPort  = "3002"
+	FreighterMetricsHost    = "0.0.0.0"
+	FreighterMetricsPort    = "9090"
 	FreighterContainerTag   = "integration-test"
 	FreighterDockerfilePath = "deployments/Dockerfile"
 
@@ -70,8 +72,24 @@ func (c *TestContainer) GetPort(ctx context.Context) (string, error) {
 }
 
 // FreighterBackendContainer wraps a TestContainer for the freighter backend service.
+// The API listens on FreighterContainerPort and Prometheus metrics on FreighterMetricsPort.
 type FreighterBackendContainer struct {
 	*TestContainer
+}
+
+// GetMetricsConnectionString returns the HTTP connection string for the internal metrics server.
+func (c *FreighterBackendContainer) GetMetricsConnectionString(ctx context.Context) (string, error) {
+	host, err := c.GetHost(ctx)
+	if err != nil {
+		return "", fmt.Errorf("getting host: %w", err)
+	}
+
+	port, err := c.MappedPort(ctx, nat.Port(FreighterMetricsPort))
+	if err != nil {
+		return "", fmt.Errorf("getting metrics port: %w", err)
+	}
+
+	return fmt.Sprintf("http://%s:%s", host, port.Port()), nil
 }
 
 // getGitCommitHash returns the current git commit hash (short form).
@@ -310,11 +328,16 @@ func createFreighterContainer(ctx context.Context, name string, imageName string
 		Labels: map[string]string{
 			"org.testcontainers.session-id": "freighter-integration-tests",
 		},
-		Cmd:          []string{"./freighter-backend", "serve"},
-		ExposedPorts: []string{fmt.Sprintf("%s/tcp", FreighterContainerPort)},
+		Cmd: []string{"./freighter-backend", "serve"},
+		ExposedPorts: []string{
+			fmt.Sprintf("%s/tcp", FreighterContainerPort),
+			fmt.Sprintf("%s/tcp", FreighterMetricsPort),
+		},
 		Env: map[string]string{
 			"FREIGHTER_BACKEND_HOST": FreighterContainerHost,
 			"FREIGHTER_BACKEND_PORT": FreighterContainerPort,
+			"METRICS_HOST":           FreighterMetricsHost,
+			"METRICS_PORT":           FreighterMetricsPort,
 			"REDIS_HOST":             RedisContainerName,
 			"REDIS_PORT":             RedisContainerPort,
 			"PUBNET_RPC_URL":         "http://stellar-rpc:8000",

--- a/internal/integrationtests/metrics_test.go
+++ b/internal/integrationtests/metrics_test.go
@@ -18,21 +18,26 @@ import (
 type MetricsTestSuite struct {
 	suite.Suite
 	freighterContainer *infrastructure.FreighterBackendContainer
-	connectionString   string
+	apiURL             string
+	metricsURL         string
 }
 
 func (s *MetricsTestSuite) SetupSuite() {
 	ctx := context.Background()
 	var err error
-	s.connectionString, err = s.freighterContainer.GetConnectionString(ctx)
+	s.apiURL, err = s.freighterContainer.GetConnectionString(ctx)
 	s.Require().NoError(err)
-	s.Require().NotEmpty(s.connectionString)
+	s.Require().NotEmpty(s.apiURL)
+
+	s.metricsURL, err = s.freighterContainer.GetMetricsConnectionString(ctx)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(s.metricsURL)
 }
 
 func (s *MetricsTestSuite) TestMetricsEndpointReturns200() {
 	t := s.T()
 
-	resp, err := http.Get(fmt.Sprintf("%s/metrics", s.connectionString))
+	resp, err := http.Get(fmt.Sprintf("%s/metrics", s.metricsURL))
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -58,14 +63,14 @@ func (s *MetricsTestSuite) TestMetricsEndpointReturns200() {
 func (s *MetricsTestSuite) TestMetricsIncrementAfterAPICall() {
 	t := s.T()
 
-	// Hit ping endpoint
-	resp, err := http.Get(fmt.Sprintf("%s/api/v1/ping", s.connectionString))
+	// Hit ping endpoint on the public API
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/ping", s.apiURL))
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	// Now check metrics
-	metricsResp, err := http.Get(fmt.Sprintf("%s/metrics", s.connectionString))
+	// Now check metrics on the internal metrics server
+	metricsResp, err := http.Get(fmt.Sprintf("%s/metrics", s.metricsURL))
 	require.NoError(t, err)
 	defer func() { _ = metricsResp.Body.Close() }()
 	require.Equal(t, http.StatusOK, metricsResp.StatusCode)
@@ -85,4 +90,15 @@ func (s *MetricsTestSuite) TestMetricsIncrementAfterAPICall() {
 		}
 	}
 	require.True(t, found, "expected to find http_requests_total counter for ping endpoint")
+}
+
+// TestMetricsNotExposedOnPublicAPI verifies the public API server does not expose /metrics —
+// it must only be reachable through the internal metrics port.
+func (s *MetricsTestSuite) TestMetricsNotExposedOnPublicAPI() {
+	t := s.T()
+
+	resp, err := http.Get(fmt.Sprintf("%s/metrics", s.apiURL))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode, "/metrics must not be served by the public API server")
 }


### PR DESCRIPTION
Why
The /metrics endpoint was registered on the public API mux (port 3002), which is exposed to the internet via the public Ingress.

What
Match v1's pattern: run two http.Servers — the public API on FreighterBackendPort (3002) and an internal metrics server on MetricsPort (default 9090). 

- Add MetricsHost/MetricsPort config and --metrics-host/--metrics-port flags (env: METRICS_HOST, METRICS_PORT)
- Split serve.go into two servers with shared SIGINT/SIGTERM shutdown
- Drop the dead /metrics skip branch from the metrics middleware
- Update integration test container to expose 9090 and expose a GetMetricsConnectionString helper
- Add tests asserting /metrics returns 404 on the public API mux