### PR TITLE
feat(ci): add prerelease publish + promote-to-release workflows

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -117,3 +117,14 @@ jobs:
             exit 1
           fi
           echo "Promotion successful — bytes preserved."
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          COMMIT_SHA: ${{ steps.resolve_sha.outputs.sha }}
+        run: |
+          gh release create "$RELEASE_VERSION" \
+            --target "$COMMIT_SHA" \
+            --title "$RELEASE_VERSION" \
+            --generate-notes

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -93,9 +93,6 @@ jobs:
       - name: ECR login via OIDC
         id: ecr_login
         uses: stellar/actions/sdf-ecr-login@main
-        with:
-          aws-oidc-role: ${{ secrets.AWS_GITHUB_OIDC_ROLE }}
-          aws-ecr-login-role: ${{ secrets.AWS_ECR_LOGIN_ROLE }}
 
       - name: Re-tag image from staging to production ECR
         env:
@@ -106,7 +103,7 @@ jobs:
           STG_TAG="${ECR_REGISTRY}/stg/freighter-backend-v2:${PRERELEASE_TAG}"
           PRD_TAG="${ECR_REGISTRY}/prd/freighter-backend-v2:${RELEASE_VERSION}"
           echo "Re-tagging $STG_TAG -> $PRD_TAG"
-          docker buildx imagetools create --tag "$PRD_TAG" "$STG_TAG"
+          docker buildx imagetools create --prefer-index=false --tag "$PRD_TAG" "$STG_TAG"
           echo "Verifying digests match..."
           STG_DIGEST=$(docker buildx imagetools inspect "$STG_TAG" --format '{{.Manifest.Digest}}')
           PRD_DIGEST=$(docker buildx imagetools inspect "$PRD_TAG" --format '{{.Manifest.Digest}}')

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -89,3 +89,31 @@ jobs:
           fi
           echo "Tag $PRERELEASE_TAG -> $SHA"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: ECR login via OIDC
+        id: ecr_login
+        uses: stellar/actions/sdf-ecr-login@main
+        with:
+          aws-oidc-role: ${{ secrets.AWS_GITHUB_OIDC_ROLE }}
+          aws-ecr-login-role: ${{ secrets.AWS_ECR_LOGIN_ROLE }}
+
+      - name: Re-tag image from staging to production ECR
+        env:
+          ECR_REGISTRY: ${{ steps.ecr_login.outputs.ecr-registry }}
+          PRERELEASE_TAG: ${{ inputs.prerelease_tag }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          STG_TAG="${ECR_REGISTRY}/stg/freighter-backend-v2:${PRERELEASE_TAG}"
+          PRD_TAG="${ECR_REGISTRY}/prd/freighter-backend-v2:${RELEASE_VERSION}"
+          echo "Re-tagging $STG_TAG -> $PRD_TAG"
+          docker buildx imagetools create --tag "$PRD_TAG" "$STG_TAG"
+          echo "Verifying digests match..."
+          STG_DIGEST=$(docker buildx imagetools inspect "$STG_TAG" --format '{{.Manifest.Digest}}')
+          PRD_DIGEST=$(docker buildx imagetools inspect "$PRD_TAG" --format '{{.Manifest.Digest}}')
+          echo "STG digest: $STG_DIGEST"
+          echo "PRD digest: $PRD_DIGEST"
+          if [[ "$STG_DIGEST" != "$PRD_DIGEST" ]]; then
+            echo "::error::Digest mismatch after re-tag: '$STG_DIGEST' vs '$PRD_DIGEST'."
+            exit 1
+          fi
+          echo "Promotion successful — bytes preserved."

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,91 @@
+# ABOUTME: Promotes an existing prerelease image from staging ECR to production ECR by re-tagging
+# ABOUTME: (no rebuild — preserves byte digest) and creates a non-prerelease GitHub release.
+name: Promote Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      prerelease_tag:
+        description: "Prerelease tag to promote (e.g., v1.2.3-rc.1)"
+        required: true
+        type: string
+      release_version:
+        description: "Release version to publish (e.g., v1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate input formats and base-version match
+        env:
+          PRERELEASE_TAG: ${{ inputs.prerelease_tag }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          if [[ ! "$PRERELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            echo "::error::Invalid prerelease_tag '$PRERELEASE_TAG'. Expected vMAJOR.MINOR.PATCH-rc.N."
+            exit 1
+          fi
+          if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release_version '$RELEASE_VERSION'. Expected vMAJOR.MINOR.PATCH."
+            exit 1
+          fi
+          BASE="${PRERELEASE_TAG%-rc.*}"
+          if [[ "$BASE" != "$RELEASE_VERSION" ]]; then
+            echo "::error::Base version mismatch: prerelease '$PRERELEASE_TAG' (base: $BASE) does not match release '$RELEASE_VERSION'."
+            exit 1
+          fi
+          echo "Inputs OK: $PRERELEASE_TAG -> $RELEASE_VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify prerelease GitHub release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE_TAG: ${{ inputs.prerelease_tag }}
+        run: |
+          if ! IS_PRE=$(gh release view "$PRERELEASE_TAG" --json isPrerelease --jq '.isPrerelease' 2>/dev/null); then
+            echo "::error::GitHub release '$PRERELEASE_TAG' not found."
+            exit 1
+          fi
+          if [[ "$IS_PRE" != "true" ]]; then
+            echo "::error::GitHub release '$PRERELEASE_TAG' exists but is not a prerelease."
+            exit 1
+          fi
+
+      - name: Verify release_version does not already exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+            echo "::error::GitHub release '$RELEASE_VERSION' already exists."
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/$RELEASE_VERSION" | grep -q .; then
+            echo "::error::Tag '$RELEASE_VERSION' already exists on origin."
+            exit 1
+          fi
+          echo "Release version '$RELEASE_VERSION' is available."
+
+      - name: Resolve commit SHA from prerelease tag
+        id: resolve_sha
+        env:
+          PRERELEASE_TAG: ${{ inputs.prerelease_tag }}
+        run: |
+          SHA=$(git rev-list -n1 "$PRERELEASE_TAG")
+          if [[ -z "$SHA" ]]; then
+            echo "::error::Could not resolve commit SHA for tag '$PRERELEASE_TAG'."
+            exit 1
+          fi
+          echo "Tag $PRERELEASE_TAG -> $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -62,3 +62,21 @@ jobs:
             exit 1
           fi
           echo "Tag '$VERSION' does not exist. Proceeding."
+
+      - name: ECR login via OIDC
+        id: ecr_login
+        uses: stellar/actions/sdf-ecr-login@main
+        with:
+          aws-oidc-role: ${{ secrets.AWS_GITHUB_OIDC_ROLE }}
+          aws-ecr-login-role: ${{ secrets.AWS_ECR_LOGIN_ROLE }}
+
+      - name: Build and push prerelease image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr_login.outputs.ecr-registry }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          TAG="${ECR_REGISTRY}/stg/freighter-backend-v2:${VERSION}"
+          echo "Building $TAG"
+          make docker-build-tag TAG="$TAG" VERSION="$VERSION"
+          echo "Pushing $TAG"
+          make docker-push TAG="$TAG"

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -9,11 +9,6 @@ on:
         description: "Prerelease version to tag (e.g., v1.2.3-rc.1)"
         required: true
         type: string
-      target_ref:
-        description: "Branch, tag, or SHA to tag (default: main)"
-        required: false
-        default: "main"
-        type: string
 
 permissions:
   id-token: write
@@ -33,20 +28,18 @@ jobs:
           fi
           echo "Version format OK: $VERSION"
 
-      - name: Checkout target_ref
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.target_ref }}
+          ref: main
           fetch-depth: 0
           fetch-tags: true
 
       - name: Resolve commit SHA
         id: resolve_sha
-        env:
-          TARGET_REF: ${{ inputs.target_ref }}
         run: |
           SHA=$(git rev-parse HEAD)
-          echo "Resolved $TARGET_REF -> $SHA"
+          echo "Resolved main -> $SHA"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
       - name: Verify tag does not exist
@@ -66,9 +59,6 @@ jobs:
       - name: ECR login via OIDC
         id: ecr_login
         uses: stellar/actions/sdf-ecr-login@main
-        with:
-          aws-oidc-role: ${{ secrets.AWS_GITHUB_OIDC_ROLE }}
-          aws-ecr-login-role: ${{ secrets.AWS_ECR_LOGIN_ROLE }}
 
       - name: Build and push prerelease image
         env:

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -80,3 +80,15 @@ jobs:
           make docker-build-tag TAG="$TAG" VERSION="$VERSION"
           echo "Pushing $TAG"
           make docker-push TAG="$TAG"
+
+      - name: Create GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          COMMIT_SHA: ${{ steps.resolve_sha.outputs.sha }}
+        run: |
+          gh release create "$VERSION" \
+            --prerelease \
+            --target "$COMMIT_SHA" \
+            --title "$VERSION" \
+            --generate-notes

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,0 +1,64 @@
+# ABOUTME: Builds and pushes a prerelease Docker image to staging ECR from a chosen ref,
+# ABOUTME: then creates a corresponding GitHub prerelease tagged at that commit.
+name: Publish Prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Prerelease version to tag (e.g., v1.2.3-rc.1)"
+        required: true
+        type: string
+      target_ref:
+        description: "Branch, tag, or SHA to tag (default: main)"
+        required: false
+        default: "main"
+        type: string
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  publish-prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+            echo "::error::Invalid version format: '$VERSION'. Expected vMAJOR.MINOR.PATCH-rc.N (e.g., v1.2.3-rc.1)."
+            exit 1
+          fi
+          echo "Version format OK: $VERSION"
+
+      - name: Checkout target_ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_ref }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve commit SHA
+        id: resolve_sha
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "Resolved $TARGET_REF -> $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag does not exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git ls-remote --tags origin "refs/tags/$VERSION" | grep -q .; then
+            echo "::error::Tag '$VERSION' already exists on origin."
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag '$VERSION' already exists locally."
+            exit 1
+          fi
+          echo "Tag '$VERSION' does not exist. Proceeding."

--- a/README.md
+++ b/README.md
@@ -13,17 +13,11 @@ gh workflow run publish-prerelease.yml \
   -f target_ref=main
 ```
 
-This builds a Docker image from the chosen ref and pushes it to:
-
-```
-746476062914.dkr.ecr.us-east-1.amazonaws.com/stg/freighter-backend-v2:v1.2.3-rc.1
-```
-
-It also creates a GitHub prerelease at the same commit.
+This builds a Docker image from the chosen ref, pushes it to the staging namespace of the internal ECR registry under the `freighter-backend-v2` repository tagged `v1.2.3-rc.1`, and creates a GitHub prerelease at the same commit.
 
 ### 2. Test the prerelease in staging
 
-Deploy `stg/freighter-backend-v2:v1.2.3-rc.1` to your staging cluster and validate.
+Deploy the staging image to your staging cluster and validate.
 
 ### 3. Promote to a release
 
@@ -33,11 +27,7 @@ gh workflow run promote-release.yml \
   -f release_version=v1.2.3
 ```
 
-This re-tags the existing staging image into the production ECR namespace (preserving the image digest — no rebuild) and creates a non-prerelease GitHub release:
-
-```
-746476062914.dkr.ecr.us-east-1.amazonaws.com/prd/freighter-backend-v2:v1.2.3
-```
+This re-tags the existing staging image into the production namespace (preserving the image digest — no rebuild) and creates a non-prerelease GitHub release.
 
 ### Tag format
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # freighter-backend-v2
 Freighter's next generation of backend system written in Go
+
+## Releases
+
+Releases follow a two-step prerelease → promote flow. Both steps run in GitHub Actions; you trigger each with `gh workflow run`.
+
+### 1. Cut a prerelease
+
+```bash
+gh workflow run publish-prerelease.yml \
+  -f version=v1.2.3-rc.1 \
+  -f target_ref=main
+```
+
+This builds a Docker image from the chosen ref and pushes it to:
+
+```
+746476062914.dkr.ecr.us-east-1.amazonaws.com/stg/freighter-backend-v2:v1.2.3-rc.1
+```
+
+It also creates a GitHub prerelease at the same commit.
+
+### 2. Test the prerelease in staging
+
+Deploy `stg/freighter-backend-v2:v1.2.3-rc.1` to your staging cluster and validate.
+
+### 3. Promote to a release
+
+```bash
+gh workflow run promote-release.yml \
+  -f prerelease_tag=v1.2.3-rc.1 \
+  -f release_version=v1.2.3
+```
+
+This re-tags the existing staging image into the production ECR namespace (preserving the image digest — no rebuild) and creates a non-prerelease GitHub release:
+
+```
+746476062914.dkr.ecr.us-east-1.amazonaws.com/prd/freighter-backend-v2:v1.2.3
+```
+
+### Tag format
+
+- Releases: `vMAJOR.MINOR.PATCH` (e.g., `v1.2.3`)
+- Prereleases: `vMAJOR.MINOR.PATCH-rc.N` (e.g., `v1.2.3-rc.1`)
+
+The workflows enforce these formats — anything else is rejected before any side effect.
+
+### Hot-fixes / cherry-picked releases
+
+Out of scope for the current setup. All releases are cut from `main`. If you need to release a fix without including newer `main` changes, revert the unwanted commits on `main` first and cut from there.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ Releases follow a two-step prerelease → promote flow. Both steps run in GitHub
 
 ```bash
 gh workflow run publish-prerelease.yml \
-  -f version=v1.2.3-rc.1 \
-  -f target_ref=main
+  -f version=v1.2.3-rc.1
 ```
 
-This builds a Docker image from the chosen ref, pushes it to the staging namespace of the internal ECR registry under the `freighter-backend-v2` repository tagged `v1.2.3-rc.1`, and creates a GitHub prerelease at the same commit.
+This builds a Docker image from the current `main` HEAD, pushes it to the staging namespace of the internal ECR registry under the `freighter-backend-v2` repository tagged `v1.2.3-rc.1`, and creates a GitHub prerelease at the same commit.
 
 ### 2. Test the prerelease in staging
 


### PR DESCRIPTION
Closes #69 

## Summary
- Adds `publish-prerelease.yml` — workflow_dispatch, builds & pushes a prerelease image from `main` HEAD to the `stg/freighter-backend-v2` namespace of the internal ECR registry, creates a GitHub prerelease.
- Adds `promote-release.yml` — workflow_dispatch, re-tags the staging image into the `prd/freighter-backend-v2` namespace (digest-preserving via `--prefer-index=false`, no rebuild), creates a non-prerelease GitHub release.
- Documents the release flow in `README.md`.

## Design
- Tag format: `vX.Y.Z` for releases, `vX.Y.Z-rc.N` for prereleases. Strict.
- Docker tag mirrors git tag verbatim (no `rc-` prefix).
- No `:latest` tag — kube manifests pin to explicit versions.
- Releases are always cut from `main` HEAD (no `target_ref` input — closes a privilege-escalation hole where feature-branch Makefile/Dockerfile would otherwise run with ECR push credentials).
- Promotion uses `docker buildx imagetools create --prefer-index=false` so the source manifest is carbon-copied (same digest) rather than wrapped in a new OCI index.
- GitHub release is only created after the image step succeeds — a failed push never produces an orphan release.

## Prerequisites (out of this PR)
- ECR repos `stg/freighter-backend-v2` and `prd/freighter-backend-v2` must exist in the internal SDF ECR registry.

(The `stellar/actions/sdf-ecr-login@main` action hardcodes its OIDC and ECR-push role ARNs internally, so no repo-level role secrets are needed.)

## Test plan
- [x] `actionlint` clean on both new files
- [ ] After merge: dispatch `publish-prerelease` with `version=v0.0.0-rc.0` → verify image in stg ECR + GitHub prerelease
- [ ] After merge: dispatch `promote-release` with `prerelease_tag=v0.0.0-rc.0`, `release_version=v0.0.0` → verify identical digest in prd ECR + non-prerelease GitHub release
- [ ] Cleanup: delete `v0.0.0-rc.0` and `v0.0.0` releases/tags + ECR images after validation

## Why workflow_dispatch and not release-event-triggered?
- Both workflows create their own GitHub releases after image steps succeed. The user's single action is "trigger the workflow" — no separate `gh release create` step that could be forgotten or misordered.
- This is symmetric (both publish and promote work the same way) and keeps side effects atomic per workflow run.

## Codex review fixes
- `--prefer-index=false` to preserve manifest digest (single-platform source).
- Remove `target_ref` input — privilege-escalation mitigation.
- Remove unused `with:` block on ECR login (the action ignored those inputs).