### PR TITLE
fix(ci): apply wallet-backend release-workflow fixes

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -102,14 +102,23 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
-          if aws ecr describe-images \
+          # Distinguish "tag absent" (ImageNotFoundException → proceed) from
+          # any other failure (auth/region/throttling/repo-missing → fail fast)
+          # so a misconfigured precheck cannot silently green-light a re-tag.
+          OUTPUT=$(aws ecr describe-images \
             --repository-name prd/freighter-backend-v2 \
             --image-ids imageTag="$RELEASE_VERSION" \
-            --region us-east-1 >/dev/null 2>&1; then
+            --region us-east-1 2>&1) && EXIT=0 || EXIT=$?
+          if [[ $EXIT -eq 0 ]]; then
             echo "::error::ECR tag prd/freighter-backend-v2:$RELEASE_VERSION already exists."
             exit 1
           fi
-          echo "ECR tag $RELEASE_VERSION not present. Proceeding."
+          if grep -q 'ImageNotFoundException' <<<"$OUTPUT"; then
+            echo "ECR tag $RELEASE_VERSION not present. Proceeding."
+          else
+            echo "::error::Unexpected error from aws ecr describe-images (exit $EXIT): $OUTPUT"
+            exit 1
+          fi
 
       - name: Re-tag image from staging to production ECR
         env:

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -98,6 +98,19 @@ jobs:
         id: ecr_login
         uses: stellar/actions/sdf-ecr-login@main
 
+      - name: Verify production ECR tag does not exist
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          if aws ecr describe-images \
+            --repository-name prd/freighter-backend-v2 \
+            --image-ids imageTag="$RELEASE_VERSION" \
+            --region us-east-1 >/dev/null 2>&1; then
+            echo "::error::ECR tag prd/freighter-backend-v2:$RELEASE_VERSION already exists."
+            exit 1
+          fi
+          echo "ECR tag $RELEASE_VERSION not present. Proceeding."
+
       - name: Re-tag image from staging to production ECR
         env:
           ECR_REGISTRY: ${{ steps.ecr_login.outputs.ecr-registry }}

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -18,6 +18,10 @@ permissions:
   id-token: write
   contents: write
 
+concurrency:
+  group: promote-release-${{ inputs.release_version }}
+  cancel-in-progress: false
+
 jobs:
   promote:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -14,6 +14,10 @@ permissions:
   id-token: write
   contents: write
 
+concurrency:
+  group: publish-prerelease-${{ inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   publish-prerelease:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -68,14 +68,23 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          if aws ecr describe-images \
+          # Distinguish "tag absent" (ImageNotFoundException → proceed) from
+          # any other failure (auth/region/throttling/repo-missing → fail fast)
+          # so a misconfigured precheck cannot silently green-light a push.
+          OUTPUT=$(aws ecr describe-images \
             --repository-name stg/freighter-backend-v2 \
             --image-ids imageTag="$VERSION" \
-            --region us-east-1 >/dev/null 2>&1; then
+            --region us-east-1 2>&1) && EXIT=0 || EXIT=$?
+          if [[ $EXIT -eq 0 ]]; then
             echo "::error::ECR tag stg/freighter-backend-v2:$VERSION already exists."
             exit 1
           fi
-          echo "ECR tag $VERSION not present. Proceeding."
+          if grep -q 'ImageNotFoundException' <<<"$OUTPUT"; then
+            echo "ECR tag $VERSION not present. Proceeding."
+          else
+            echo "::error::Unexpected error from aws ecr describe-images (exit $EXIT): $OUTPUT"
+            exit 1
+          fi
 
       - name: Build and push prerelease image
         env:

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -64,6 +64,19 @@ jobs:
         id: ecr_login
         uses: stellar/actions/sdf-ecr-login@main
 
+      - name: Verify ECR tag does not exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if aws ecr describe-images \
+            --repository-name stg/freighter-backend-v2 \
+            --image-ids imageTag="$VERSION" \
+            --region us-east-1 >/dev/null 2>&1; then
+            echo "::error::ECR tag stg/freighter-backend-v2:$VERSION already exists."
+            exit 1
+          fi
+          echo "ECR tag $VERSION not present. Proceeding."
+
       - name: Build and push prerelease image
         env:
           ECR_REGISTRY: ${{ steps.ecr_login.outputs.ecr-registry }}


### PR DESCRIPTION
## Summary

Ports the release-workflow fixes from [stellar/wallet-backend@77584c6](https://github.com/stellar/wallet-backend/commit/77584c6fef89eb37228544f2364ab914ccba0b67) into freighter-backend-v2. The original prerelease + promote-to-release workflows here (PR #96) were modeled on wallet-backend's; that repo got post-review fixes that we missed.

Two behavioral changes, one per commit:

1. **Concurrency groups** on both workflows. Same-version dispatches now serialize instead of racing into ECR. `cancel-in-progress: false` so a retry waits for the in-flight push rather than interrupting it mid-write.
   - `publish-prerelease`: group `publish-prerelease-${{ inputs.version }}`
   - `promote-release`: group `promote-release-${{ inputs.release_version }}`
2. **Pre-push ECR `describe-images` precheck** on both workflows. Fails fast before any ECR mutation if the destination tag (`stg/freighter-backend-v2:$VERSION` or `prd/freighter-backend-v2:$RELEASE_VERSION`) already exists, complementing the existing GitHub-side release/tag checks.

### Deliberately not ported

The upstream commit also flipped `BUILD_DATE := …` to `BUILD_DATE ?= …` in the Makefile so the workflow could export a build timestamp into the OCI label. Our analogous variable is `BUILD_TIME` (Makefile:10) and neither workflow currently exports it to `make docker-build-tag`, so the `:=` isn't a live footgun here. Left as-is per CLAUDE.md's no-changes-for-hypothetical-futures guidance.

## Test plan

- [ ] CI green on this PR (Actions schema parser validates the new `concurrency:` blocks and steps without dispatching the workflows).
- [ ] `git diff main -- .github/workflows/` shows only the four insertions described above and no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)