### PR TITLE
feat: account-history — single transactions endpoint with embedded ops + state changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,12 @@ deadcode: ## Find unused code
 		echo "✅ No deadcode found"; \
 	fi
 
-check: tidy fmt vet lint generate shadow exhaustive deadcode ## Run all checks
+# exhaustive is intentionally omitted from `check`: golangci-lint already runs the
+# exhaustive analyzer with the same settings (see .golangci.yml), so the standalone
+# target is redundant. It is also kept out of the chain because exhaustive@v0.12.0
+# (its latest release) pins x/tools@v0.15.0, which fails to compile under Go 1.26.
+# Run `make exhaustive` directly on Go <=1.25 if you want the standalone tool.
+check: tidy fmt vet lint generate shadow deadcode ## Run all checks
 	@echo "✅ All checks completed successfully"
 
 # ==================================================================================== #

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -33,6 +33,9 @@ func (s *ServeCmd) Command() *cobra.Command {
 			if n := s.Cfg.AppConfig.WalletBackendBalanceConcurrency; n <= 0 {
 				return fmt.Errorf("--wallet-backend-balance-concurrency=%d must be positive", n)
 			}
+			if d, m := s.Cfg.AppConfig.AccountHistoryDefaultLimit, s.Cfg.AppConfig.AccountHistoryMaxLimit; d <= 0 || m <= 0 || d > m {
+				return fmt.Errorf("--account-history-default-limit=%d / --account-history-max-limit=%d must be positive and default <= max", d, m)
+			}
 			return nil
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -60,6 +63,8 @@ func (s *ServeCmd) Command() *cobra.Command {
 	cmd.Flags().IntVar(&s.Cfg.AppConfig.MaxBalanceAddresses, "max-balance-addresses", 100, "Maximum number of addresses allowed in account balances request")
 	cmd.Flags().IntVar(&s.Cfg.AppConfig.MaxLedgerKeyAddresses, "max-ledger-key-addresses", 100, "Maximum number of public keys allowed in a ledger-key/accounts request")
 	cmd.Flags().IntVar(&s.Cfg.AppConfig.WalletBackendBalanceConcurrency, "wallet-backend-balance-concurrency", 10, "Per-request maximum number of concurrent wallet-backend balance fetches (the /accounts/balances handler fans out to one accountByAddress call per address)")
+	cmd.Flags().IntVar(&s.Cfg.AppConfig.AccountHistoryDefaultLimit, "account-history-default-limit", 20, "Default page size for /accounts/{address}/transactions, /operations, /state-changes")
+	cmd.Flags().IntVar(&s.Cfg.AppConfig.AccountHistoryMaxLimit, "account-history-max-limit", 100, "Maximum page size for the same account-history endpoints")
 
 	// RPC Config
 	cmd.Flags().StringVar(&s.Cfg.RpcConfig.PubnetRpcUrl, "pubnet-rpc-url", "", "The Pubnet URL of the Pubnet RPC instance")

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -2,11 +2,11 @@ package serve
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stellar/freighter-backend-v2/internal/api"
+	"github.com/stellar/freighter-backend-v2/internal/api/handlers"
 	"github.com/stellar/freighter-backend-v2/internal/config"
 	"github.com/stellar/freighter-backend-v2/internal/services"
 	"github.com/stellar/freighter-backend-v2/internal/utils"
@@ -34,8 +34,8 @@ func (s *ServeCmd) Command() *cobra.Command {
 			if n := s.Cfg.AppConfig.WalletBackendBalanceConcurrency; n <= 0 {
 				return fmt.Errorf("--wallet-backend-balance-concurrency=%d must be positive", n)
 			}
-			if d, m := s.Cfg.AppConfig.AccountHistoryDefaultLimit, s.Cfg.AppConfig.AccountHistoryMaxLimit; d <= 0 || m <= 0 || d > m || m > math.MaxInt32 {
-				return fmt.Errorf("--account-history-default-limit=%d / --account-history-max-limit=%d must be positive, default <= max, and max <= %d", d, m, math.MaxInt32)
+			if d, m := s.Cfg.AppConfig.AccountHistoryDefaultLimit, s.Cfg.AppConfig.AccountHistoryMaxLimit; d <= 0 || m <= 0 || d > m || m > handlers.AccountHistoryUpstreamMaxLimit {
+				return fmt.Errorf("--account-history-default-limit=%d / --account-history-max-limit=%d must be positive, default <= max, and max <= %d", d, m, handlers.AccountHistoryUpstreamMaxLimit)
 			}
 			return nil
 		},
@@ -64,8 +64,8 @@ func (s *ServeCmd) Command() *cobra.Command {
 	cmd.Flags().IntVar(&s.Cfg.AppConfig.MaxBalanceAddresses, "max-balance-addresses", 100, "Maximum number of addresses allowed in account balances request")
 	cmd.Flags().IntVar(&s.Cfg.AppConfig.MaxLedgerKeyAddresses, "max-ledger-key-addresses", 100, "Maximum number of public keys allowed in a ledger-key/accounts request")
 	cmd.Flags().IntVar(&s.Cfg.AppConfig.WalletBackendBalanceConcurrency, "wallet-backend-balance-concurrency", 10, "Per-request maximum number of concurrent wallet-backend balance fetches (the /accounts/balances handler fans out to one accountByAddress call per address)")
-	cmd.Flags().IntVar(&s.Cfg.AppConfig.AccountHistoryDefaultLimit, "account-history-default-limit", 20, "Default page size for /accounts/{address}/transactions, /operations, /state-changes")
-	cmd.Flags().IntVar(&s.Cfg.AppConfig.AccountHistoryMaxLimit, "account-history-max-limit", 100, "Maximum page size for the same account-history endpoints")
+	cmd.Flags().IntVar(&s.Cfg.AppConfig.AccountHistoryDefaultLimit, "account-history-default-limit", 20, "Default page size for GET /accounts/{address}/transactions")
+	cmd.Flags().IntVar(&s.Cfg.AppConfig.AccountHistoryMaxLimit, "account-history-max-limit", 100, "Maximum page size for GET /accounts/{address}/transactions (upstream hard-caps at 100)")
 
 	// RPC Config
 	cmd.Flags().StringVar(&s.Cfg.RpcConfig.PubnetRpcUrl, "pubnet-rpc-url", "", "The Pubnet URL of the Pubnet RPC instance")

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -2,6 +2,7 @@ package serve
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/spf13/cobra"
 
@@ -33,8 +34,8 @@ func (s *ServeCmd) Command() *cobra.Command {
 			if n := s.Cfg.AppConfig.WalletBackendBalanceConcurrency; n <= 0 {
 				return fmt.Errorf("--wallet-backend-balance-concurrency=%d must be positive", n)
 			}
-			if d, m := s.Cfg.AppConfig.AccountHistoryDefaultLimit, s.Cfg.AppConfig.AccountHistoryMaxLimit; d <= 0 || m <= 0 || d > m {
-				return fmt.Errorf("--account-history-default-limit=%d / --account-history-max-limit=%d must be positive and default <= max", d, m)
+			if d, m := s.Cfg.AppConfig.AccountHistoryDefaultLimit, s.Cfg.AppConfig.AccountHistoryMaxLimit; d <= 0 || m <= 0 || d > m || m > math.MaxInt32 {
+				return fmt.Errorf("--account-history-default-limit=%d / --account-history-max-limit=%d must be positive, default <= max, and max <= %d", d, m, math.MaxInt32)
 			}
 			return nil
 		},

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -115,7 +114,7 @@ func TestServeCmd_AcceptsMaxLedgerKeyAddressesAtUpstreamCeiling(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 }
 
-func TestServeCmd_RejectsAccountHistoryMaxLimitAboveMaxInt32(t *testing.T) {
+func TestServeCmd_RejectsAccountHistoryMaxLimitAbove100(t *testing.T) {
 	t.Parallel()
 
 	serveCmd := &ServeCmd{Cfg: &config.Config{}}
@@ -123,13 +122,12 @@ func TestServeCmd_RejectsAccountHistoryMaxLimitAboveMaxInt32(t *testing.T) {
 	cmd.RunE = func(*cobra.Command, []string) error { return nil }
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
-	// math.MaxInt32+1 overflows int on 32-bit but is safe on 64-bit (our target).
 	cmd.SetArgs([]string{
 		"--account-history-default-limit", "20",
-		"--account-history-max-limit", fmt.Sprintf("%d", math.MaxInt32+1),
+		"--account-history-max-limit", "101",
 	})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), fmt.Sprintf("max <= %d", math.MaxInt32))
+	assert.Contains(t, err.Error(), "max <= 100")
 }

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -112,4 +113,23 @@ func TestServeCmd_AcceptsMaxLedgerKeyAddressesAtUpstreamCeiling(t *testing.T) {
 	cmd.SetArgs([]string{"--max-ledger-key-addresses", fmt.Sprintf("%d", services.MaxLedgerEntryKeys)})
 
 	require.NoError(t, cmd.Execute())
+}
+
+func TestServeCmd_RejectsAccountHistoryMaxLimitAboveMaxInt32(t *testing.T) {
+	t.Parallel()
+
+	serveCmd := &ServeCmd{Cfg: &config.Config{}}
+	cmd := serveCmd.Command()
+	cmd.RunE = func(*cobra.Command, []string) error { return nil }
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	// math.MaxInt32+1 overflows int on 32-bit but is safe on 64-bit (our target).
+	cmd.SetArgs([]string{
+		"--account-history-default-limit", "20",
+		"--account-history-max-limit", fmt.Sprintf("%d", math.MaxInt32+1),
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("max <= %d", math.MaxInt32))
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stellar/go v0.0.0-20250903085211-00c0b06cd7cc
 	github.com/stellar/go-stellar-sdk v0.5.0
-	github.com/stellar/wallet-backend v0.0.0-20260514162152-e41e6a4badfe
+	github.com/stellar/wallet-backend v0.0.0-20260602140614-12c1f20c37b7
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.37.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stellar/go v0.0.0-20250903085211-00c0b06cd7cc
 	github.com/stellar/go-stellar-sdk v0.5.0
-	github.com/stellar/wallet-backend v0.0.0-20260513200934-833411fa21cb
+	github.com/stellar/wallet-backend v0.0.0-20260514162152-e41e6a4badfe
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.37.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stellar/go v0.0.0-20250903085211-00c0b06cd7cc
 	github.com/stellar/go-stellar-sdk v0.5.0
-	github.com/stellar/wallet-backend v0.0.0-20260508205938-6af051992454
+	github.com/stellar/wallet-backend v0.0.0-20260513200934-833411fa21cb
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.37.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stellar/go v0.0.0-20250903085211-00c0b06cd7cc
 	github.com/stellar/go-stellar-sdk v0.5.0
-	github.com/stellar/wallet-backend v0.0.0-20260602140614-12c1f20c37b7
+	github.com/stellar/wallet-backend v0.0.0-20260615202139-92c44d7e4815
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/stellar/go-stellar-sdk v0.5.0 h1:xpOO+ZTyvGz54wTm7pwl2Gf1e6lZl0ExrJ/t
 github.com/stellar/go-stellar-sdk v0.5.0/go.mod h1:tLKAQPxa2I5UvGMabBbUXcY3fmgYnfDudrMeK7CDX4w=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf h1:GY1RVbX3Hg7poPXEf6yojjP0hyypvgUgZmCqQU9D0xg=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
-github.com/stellar/wallet-backend v0.0.0-20260602140614-12c1f20c37b7 h1:DC6RXwOh62HrVXmxtIuASNAqTf5QIaeELg6F9hA366A=
-github.com/stellar/wallet-backend v0.0.0-20260602140614-12c1f20c37b7/go.mod h1:TksDi8jU6z3YQr4t14VZxXk3czYzo7vNQjFKpl1xUOE=
+github.com/stellar/wallet-backend v0.0.0-20260615202139-92c44d7e4815 h1:l7+joj24waunZdTYDti/nI+SJEpsrW5WnH8v6bCCNHk=
+github.com/stellar/wallet-backend v0.0.0-20260615202139-92c44d7e4815/go.mod h1:TksDi8jU6z3YQr4t14VZxXk3czYzo7vNQjFKpl1xUOE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/stellar/go-stellar-sdk v0.5.0 h1:xpOO+ZTyvGz54wTm7pwl2Gf1e6lZl0ExrJ/t
 github.com/stellar/go-stellar-sdk v0.5.0/go.mod h1:tLKAQPxa2I5UvGMabBbUXcY3fmgYnfDudrMeK7CDX4w=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf h1:GY1RVbX3Hg7poPXEf6yojjP0hyypvgUgZmCqQU9D0xg=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
-github.com/stellar/wallet-backend v0.0.0-20260508205938-6af051992454 h1:fSx8s9QNp8JRx2UrSCraDP2qbJRCkCNHIkNcGvCJjVs=
-github.com/stellar/wallet-backend v0.0.0-20260508205938-6af051992454/go.mod h1:TksDi8jU6z3YQr4t14VZxXk3czYzo7vNQjFKpl1xUOE=
+github.com/stellar/wallet-backend v0.0.0-20260513200934-833411fa21cb h1:lFXW+d2cOg86r1I3rIRIUY0Fql1L4aoiaLPRISDPaJY=
+github.com/stellar/wallet-backend v0.0.0-20260513200934-833411fa21cb/go.mod h1:TksDi8jU6z3YQr4t14VZxXk3czYzo7vNQjFKpl1xUOE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/stellar/go-stellar-sdk v0.5.0 h1:xpOO+ZTyvGz54wTm7pwl2Gf1e6lZl0ExrJ/t
 github.com/stellar/go-stellar-sdk v0.5.0/go.mod h1:tLKAQPxa2I5UvGMabBbUXcY3fmgYnfDudrMeK7CDX4w=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf h1:GY1RVbX3Hg7poPXEf6yojjP0hyypvgUgZmCqQU9D0xg=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
-github.com/stellar/wallet-backend v0.0.0-20260513200934-833411fa21cb h1:lFXW+d2cOg86r1I3rIRIUY0Fql1L4aoiaLPRISDPaJY=
-github.com/stellar/wallet-backend v0.0.0-20260513200934-833411fa21cb/go.mod h1:TksDi8jU6z3YQr4t14VZxXk3czYzo7vNQjFKpl1xUOE=
+github.com/stellar/wallet-backend v0.0.0-20260514162152-e41e6a4badfe h1:/q+JL+IohHzvpAFaVuetQlYks2Is/1IJpjZQdC8kHdQ=
+github.com/stellar/wallet-backend v0.0.0-20260514162152-e41e6a4badfe/go.mod h1:TksDi8jU6z3YQr4t14VZxXk3czYzo7vNQjFKpl1xUOE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/stellar/go-stellar-sdk v0.5.0 h1:xpOO+ZTyvGz54wTm7pwl2Gf1e6lZl0ExrJ/t
 github.com/stellar/go-stellar-sdk v0.5.0/go.mod h1:tLKAQPxa2I5UvGMabBbUXcY3fmgYnfDudrMeK7CDX4w=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf h1:GY1RVbX3Hg7poPXEf6yojjP0hyypvgUgZmCqQU9D0xg=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
-github.com/stellar/wallet-backend v0.0.0-20260514162152-e41e6a4badfe h1:/q+JL+IohHzvpAFaVuetQlYks2Is/1IJpjZQdC8kHdQ=
-github.com/stellar/wallet-backend v0.0.0-20260514162152-e41e6a4badfe/go.mod h1:TksDi8jU6z3YQr4t14VZxXk3czYzo7vNQjFKpl1xUOE=
+github.com/stellar/wallet-backend v0.0.0-20260602140614-12c1f20c37b7 h1:DC6RXwOh62HrVXmxtIuASNAqTf5QIaeELg6F9hA366A=
+github.com/stellar/wallet-backend v0.0.0-20260602140614-12c1f20c37b7/go.mod h1:TksDi8jU6z3YQr4t14VZxXk3czYzo7vNQjFKpl1xUOE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/internal/api/handlers/account_balances.go
+++ b/internal/api/handlers/account_balances.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
 	response "github.com/stellar/freighter-backend-v2/internal/api/httpresponse"
 	"github.com/stellar/freighter-backend-v2/internal/api/middleware"
-	"github.com/stellar/freighter-backend-v2/internal/logger"
 	"github.com/stellar/freighter-backend-v2/internal/types"
 )
 
@@ -74,8 +73,8 @@ func (h *AccountBalancesHandler) GetAccountBalances(w http.ResponseWriter, r *ht
 	queryParams := r.URL.Query()
 	network := queryParams.Get("network")
 
-	if !isValidNetwork(network) {
-		return httperror.BadRequest(fmt.Sprintf("invalid network: network must be %s, %s or %s", types.PUBLIC, types.TESTNET, types.FUTURENET), errors.New("invalid network"))
+	if !isValidWalletBackendNetwork(network) {
+		return httperror.BadRequest(fmt.Sprintf("invalid network: must be %s or %s", types.PUBLIC, types.TESTNET), errors.New("invalid network"))
 	}
 
 	req, validationErr := validateAccountBalancesRequest(r, h.MaxAddresses)
@@ -85,8 +84,12 @@ func (h *AccountBalancesHandler) GetAccountBalances(w http.ResponseWriter, r *ht
 
 	balances, err := h.WalletBackendService.GetBalancesByAccountAddresses(contextWithTimeout, req.Addresses, network)
 	if err != nil {
-		logger.ErrorWithContext(r.Context(), "getting account balances from wallet backend", "error", err)
-		return httperror.InternalServerError("Failed to get account balances", err)
+		// address is intentionally empty: this is a multi-address fan-out
+		// endpoint, and individual ErrAccountNotFound outcomes are already
+		// surfaced as per-address Error strings inside a 200 body. The top-level
+		// err here is only ever a systemic failure (graphql_error, http_error,
+		// connection, timeout, internal).
+		return translateServiceError(r.Context(), err, "account balances", "", network)
 	}
 
 	responseData := HttpResponse{

--- a/internal/api/handlers/account_balances_test.go
+++ b/internal/api/handlers/account_balances_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
+	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/utils"
 )
 
@@ -116,7 +119,7 @@ func TestGetAccountBalances(t *testing.T) {
 
 		err := handler.GetAccountBalances(rr, req)
 		require.Error(t, err)
-		assert.EqualError(t, err, "invalid network: network must be PUBLIC, TESTNET or FUTURENET")
+		assert.EqualError(t, err, "invalid network: must be PUBLIC or TESTNET")
 	})
 
 	t.Run("should return error for empty addresses array", func(t *testing.T) {
@@ -273,4 +276,47 @@ func TestGetAccountBalances(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rr.Code)
 	})
+}
+
+func TestGetAccountBalances_UpstreamErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	const validBody = `{"addresses":["GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"]}`
+
+	cases := []struct {
+		name       string
+		mockErr    error
+		wantStatus int
+	}{
+		{"graphql_error -> 502", &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}, http.StatusBadGateway},
+		{"http_error -> 502", &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}, http.StatusBadGateway},
+		{"ctx deadline -> 504", context.DeadlineExceeded, http.StatusGatewayTimeout},
+		{"generic -> 500", errors.New("boom"), http.StatusInternalServerError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockSvc := &utils.MockWalletBackendService{GetBalancesError: tc.mockErr}
+			h := NewAccountBalancesHandler(mockSvc, 100)
+			req := httptest.NewRequest("POST", "/api/v1/accounts/balances?network=PUBLIC", strings.NewReader(validBody))
+			rr := httptest.NewRecorder()
+			err := h.GetAccountBalances(rr, req)
+			var herr *httperror.HttpError
+			require.True(t, errors.As(err, &herr))
+			assert.Equal(t, tc.wantStatus, herr.StatusCode)
+		})
+	}
+}
+
+func TestGetAccountBalances_RejectsFuturenet(t *testing.T) {
+	t.Parallel()
+	mockSvc := &utils.MockWalletBackendService{}
+	h := NewAccountBalancesHandler(mockSvc, 100)
+	req := httptest.NewRequest("POST", "/api/v1/accounts/balances?network=FUTURENET", strings.NewReader(`{"addresses":["GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"]}`))
+	rr := httptest.NewRecorder()
+	err := h.GetAccountBalances(rr, req)
+	var herr *httperror.HttpError
+	require.True(t, errors.As(err, &herr))
+	assert.Equal(t, http.StatusBadRequest, herr.StatusCode)
 }

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -191,3 +191,25 @@ func (h *AccountHistoryHandler) GetAccountOperations(w http.ResponseWriter, r *h
 	w.Header().Set("Content-Type", "application/json")
 	return response.OK(w, result)
 }
+
+// GetAccountStateChanges returns one page of an account's state changes from
+// wallet-backend, in the PaginatedResponse[T] envelope. The Data slice elements
+// are polymorphic wbtypes.StateChangeNode values (concrete type determined by
+// the upstream __typename discriminator).
+func (h *AccountHistoryHandler) GetAccountStateChanges(w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithTimeout(r.Context(), AccountHistoryContextTimeout)
+	defer cancel()
+
+	address, network, params, herr := h.parseRequest(r)
+	if herr != nil {
+		return herr
+	}
+
+	result, err := h.WalletBackendService.GetAccountStateChanges(ctx, address, network, params)
+	if err != nil {
+		return translateServiceError(r.Context(), err, "account state changes", address, network)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return response.OK(w, result)
+}

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stellar/wallet-backend/pkg/wbclient"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
+	response "github.com/stellar/freighter-backend-v2/internal/api/httpresponse"
 	"github.com/stellar/freighter-backend-v2/internal/logger"
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/types"
@@ -149,4 +150,24 @@ func (h *AccountHistoryHandler) parseRequest(r *http.Request) (address, network 
 	}
 
 	return address, network, p, nil
+}
+
+// GetAccountTransactions returns one page of an account's transactions from
+// wallet-backend, in the spec's PaginatedResponse[T] envelope.
+func (h *AccountHistoryHandler) GetAccountTransactions(w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithTimeout(r.Context(), AccountHistoryContextTimeout)
+	defer cancel()
+
+	address, network, params, herr := h.parseRequest(r)
+	if herr != nil {
+		return herr
+	}
+
+	result, err := h.WalletBackendService.GetAccountTransactions(ctx, address, network, params)
+	if err != nil {
+		return translateServiceError(r.Context(), err, "account transactions", address, network)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return response.OK(w, result)
 }

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -7,13 +7,18 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
+	"github.com/stellar/go/strkey"
 	"github.com/stellar/wallet-backend/pkg/wbclient"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
 	"github.com/stellar/freighter-backend-v2/internal/logger"
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
+	"github.com/stellar/freighter-backend-v2/internal/types"
 )
 
 // translateServiceError maps a service-layer error to a typed HttpError per
@@ -50,4 +55,98 @@ func translateServiceError(ctx context.Context, err error, resource, address, ne
 	}
 	logger.ErrorWithContext(ctx, "wallet-backend call failed", "resource", resource, "address", address, "network", network, "error", err)
 	return httperror.InternalServerError(fmt.Sprintf("Failed to get %s", resource), err)
+}
+
+// AccountHistoryContextTimeout caps each /accounts/{address}/{...} request
+// at 10s. Matches AccountBalancesContextTimeout.
+const AccountHistoryContextTimeout = 10 * time.Second
+
+// AccountHistoryHandler serves the three account-scoped paginated history
+// endpoints. All three methods route through parseRequest and translateServiceError.
+type AccountHistoryHandler struct {
+	WalletBackendService types.WalletBackendService
+	DefaultLimit         int
+	MaxLimit             int
+}
+
+// NewAccountHistoryHandler returns a handler configured with the given page
+// size bounds. Returns an error on invalid inputs so cmd/serve fails fast at
+// startup, matching NewWalletBackendService's pattern.
+func NewAccountHistoryHandler(svc types.WalletBackendService, defaultLimit, maxLimit int) (*AccountHistoryHandler, error) {
+	if defaultLimit <= 0 {
+		return nil, fmt.Errorf("account-history default limit must be > 0, got %d", defaultLimit)
+	}
+	if maxLimit <= 0 {
+		return nil, fmt.Errorf("account-history max limit must be > 0, got %d", maxLimit)
+	}
+	if defaultLimit > maxLimit {
+		return nil, fmt.Errorf("account-history default limit (%d) must be <= max limit (%d)", defaultLimit, maxLimit)
+	}
+	return &AccountHistoryHandler{
+		WalletBackendService: svc,
+		DefaultLimit:         defaultLimit,
+		MaxLimit:             maxLimit,
+	}, nil
+}
+
+// parseRequest extracts and validates the address path variable, the network
+// query param, and the cursor/pagination/time-range query params, returning
+// the AccountHistoryParams ready to hand to the service. Returns *httperror.HttpError
+// (always status 400) on any validation failure.
+func (h *AccountHistoryHandler) parseRequest(r *http.Request) (address, network string, p types.AccountHistoryParams, herr *httperror.HttpError) {
+	address = r.PathValue("address")
+	if _, err := strkey.Decode(strkey.VersionByteAccountID, address); err != nil {
+		return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid Stellar address %s: %s", address, err.Error()), err)
+	}
+
+	network = r.URL.Query().Get("network")
+	if !isValidWalletBackendNetwork(network) {
+		return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid network: must be %s or %s", types.PUBLIC, types.TESTNET), errors.New("invalid network"))
+	}
+
+	limit := h.DefaultLimit
+	if s := r.URL.Query().Get("limit"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid limit %q: not an integer", s), err)
+		}
+		if n < 1 || n > h.MaxLimit {
+			return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid limit %d: must be between 1 and %d", n, h.MaxLimit), errors.New("limit out of range"))
+		}
+		limit = n
+	}
+	p.Limit = int32(limit)
+
+	switch d := r.URL.Query().Get("direction"); d {
+	case "", string(types.PaginationDirectionNext):
+		p.Direction = types.PaginationDirectionNext
+	case string(types.PaginationDirectionPrev):
+		p.Direction = types.PaginationDirectionPrev
+	default:
+		return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid direction %q: must be %q or %q", d, types.PaginationDirectionNext, types.PaginationDirectionPrev), errors.New("invalid direction"))
+	}
+
+	if c := r.URL.Query().Get("cursor"); c != "" {
+		p.Cursor = &c
+	}
+
+	if s := r.URL.Query().Get("since"); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid since %q: must be RFC3339", s), err)
+		}
+		p.Since = &t
+	}
+	if u := r.URL.Query().Get("until"); u != "" {
+		t, err := time.Parse(time.RFC3339, u)
+		if err != nil {
+			return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid until %q: must be RFC3339", u), err)
+		}
+		p.Until = &t
+	}
+	if p.Since != nil && p.Until != nil && p.Since.After(*p.Until) {
+		return "", "", types.AccountHistoryParams{}, httperror.BadRequest("since must be before until", errors.New("since after until"))
+	}
+
+	return address, network, p, nil
 }

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -22,6 +22,11 @@ import (
 // at 10s. Matches AccountBalancesContextTimeout.
 const AccountHistoryContextTimeout = 10 * time.Second
 
+// AccountHistoryUpstreamMaxLimit is the wallet-backend page-size ceiling (it
+// returns BAD_USER_INPUT beyond 100). freighter rejects a larger configured
+// max limit so a misconfiguration fails fast instead of 502-ing at request time.
+const AccountHistoryUpstreamMaxLimit = 100
+
 // AccountHistoryHandler serves the single account-scoped transactions history
 // endpoint. GetAccountTransactions routes through parseRequest and translateServiceError.
 type AccountHistoryHandler struct {
@@ -40,8 +45,8 @@ func NewAccountHistoryHandler(svc types.WalletBackendService, defaultLimit, maxL
 	if maxLimit <= 0 {
 		return nil, fmt.Errorf("account-history max limit must be > 0, got %d", maxLimit)
 	}
-	if maxLimit > math.MaxInt32 {
-		return nil, fmt.Errorf("account-history max limit must be <= %d, got %d", math.MaxInt32, maxLimit)
+	if maxLimit > AccountHistoryUpstreamMaxLimit {
+		return nil, fmt.Errorf("account-history max limit must be <= %d, got %d", AccountHistoryUpstreamMaxLimit, maxLimit)
 	}
 	if defaultLimit > maxLimit {
 		return nil, fmt.Errorf("account-history default limit (%d) must be <= max limit (%d)", defaultLimit, maxLimit)

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -80,6 +81,9 @@ func NewAccountHistoryHandler(svc types.WalletBackendService, defaultLimit, maxL
 	if maxLimit <= 0 {
 		return nil, fmt.Errorf("account-history max limit must be > 0, got %d", maxLimit)
 	}
+	if maxLimit > math.MaxInt32 {
+		return nil, fmt.Errorf("account-history max limit must be <= %d, got %d", math.MaxInt32, maxLimit)
+	}
 	if defaultLimit > maxLimit {
 		return nil, fmt.Errorf("account-history default limit (%d) must be <= max limit (%d)", defaultLimit, maxLimit)
 	}
@@ -111,7 +115,7 @@ func (h *AccountHistoryHandler) parseRequest(r *http.Request) (address, network 
 		if err != nil {
 			return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid limit %q: not an integer", s), err)
 		}
-		if n < 1 || n > h.MaxLimit {
+		if n < 1 || n > h.MaxLimit || n > math.MaxInt32 {
 			return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid limit %d: must be between 1 and %d", n, h.MaxLimit), errors.New("limit out of range"))
 		}
 		limit = n

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -7,57 +7,16 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/stellar/go/strkey"
-	"github.com/stellar/wallet-backend/pkg/wbclient"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
 	response "github.com/stellar/freighter-backend-v2/internal/api/httpresponse"
-	"github.com/stellar/freighter-backend-v2/internal/logger"
-	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/types"
 )
-
-// translateServiceError maps a service-layer error to a typed HttpError per
-// the spec's REST-honest mapping. Logs all non-404 errors with context;
-// account-not-found is a normal client outcome and is not logged.
-//
-// Status mapping:
-//   - wbclient.ErrAccountNotFound       -> 404
-//   - context.DeadlineExceeded/Canceled -> 504
-//   - *metrics.UpstreamError (any Kind) -> 502 (graphql_error, http_error)
-//   - *url.Error / *net.OpError         -> 502 (transport / DNS / dial)
-//   - anything else                     -> 500
-func translateServiceError(ctx context.Context, err error, resource, address, network string) *httperror.HttpError {
-	switch {
-	case errors.Is(err, wbclient.ErrAccountNotFound):
-		return httperror.NotFound(fmt.Sprintf("%s not found", resource), err)
-	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
-		logger.ErrorWithContext(ctx, "wallet-backend call timed out", "resource", resource, "address", address, "network", network, "error", err)
-		return httperror.GatewayTimeout(fmt.Sprintf("Failed to get %s", resource), err)
-	}
-	var upErr *metrics.UpstreamError
-	if errors.As(err, &upErr) {
-		logger.ErrorWithContext(ctx, "wallet-backend upstream error", "resource", resource, "address", address, "network", network, "kind", upErr.Kind, "code", upErr.Code, "error", err)
-		return httperror.BadGateway(fmt.Sprintf("Failed to get %s", resource), err)
-	}
-	// Transport-layer failures come back from the SDK unwrapped (the SDK's
-	// classifyWBError patterns only match GraphQL / HTTP-status strings).
-	// Map them to 502 as the spec requires.
-	var urlErr *url.Error
-	var netErr *net.OpError
-	if errors.As(err, &urlErr) || errors.As(err, &netErr) {
-		logger.ErrorWithContext(ctx, "wallet-backend transport error", "resource", resource, "address", address, "network", network, "error", err)
-		return httperror.BadGateway(fmt.Sprintf("Failed to get %s", resource), err)
-	}
-	logger.ErrorWithContext(ctx, "wallet-backend call failed", "resource", resource, "address", address, "network", network, "error", err)
-	return httperror.InternalServerError(fmt.Sprintf("Failed to get %s", resource), err)
-}
 
 // AccountHistoryContextTimeout caps each /accounts/{address}/{...} request
 // at 10s. Matches AccountBalancesContextTimeout.

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -1,0 +1,53 @@
+// ABOUTME: HTTP handlers for the account-history endpoints (transactions / operations / state-changes).
+// ABOUTME: Shares parseRequest and translateServiceError helpers, all going through wallet-backend's GraphQL API.
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/stellar/wallet-backend/pkg/wbclient"
+
+	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
+	"github.com/stellar/freighter-backend-v2/internal/logger"
+	"github.com/stellar/freighter-backend-v2/internal/metrics"
+)
+
+// translateServiceError maps a service-layer error to a typed HttpError per
+// the spec's REST-honest mapping. Logs all non-404 errors with context;
+// account-not-found is a normal client outcome and is not logged.
+//
+// Status mapping:
+//   - wbclient.ErrAccountNotFound       -> 404
+//   - context.DeadlineExceeded/Canceled -> 504
+//   - *metrics.UpstreamError (any Kind) -> 502 (graphql_error, http_error)
+//   - *url.Error / *net.OpError         -> 502 (transport / DNS / dial)
+//   - anything else                     -> 500
+func translateServiceError(ctx context.Context, err error, resource, address, network string) *httperror.HttpError {
+	switch {
+	case errors.Is(err, wbclient.ErrAccountNotFound):
+		return httperror.NotFound(fmt.Sprintf("%s not found", resource), err)
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		logger.ErrorWithContext(ctx, "wallet-backend call timed out", "resource", resource, "address", address, "network", network, "error", err)
+		return httperror.GatewayTimeout(fmt.Sprintf("Failed to get %s", resource), err)
+	}
+	var upErr *metrics.UpstreamError
+	if errors.As(err, &upErr) {
+		logger.ErrorWithContext(ctx, "wallet-backend upstream error", "resource", resource, "address", address, "network", network, "kind", upErr.Kind, "code", upErr.Code, "error", err)
+		return httperror.BadGateway(fmt.Sprintf("Failed to get %s", resource), err)
+	}
+	// Transport-layer failures come back from the SDK unwrapped (the SDK's
+	// classifyWBError patterns only match GraphQL / HTTP-status strings).
+	// Map them to 502 as the spec requires.
+	var urlErr *url.Error
+	var netErr *net.OpError
+	if errors.As(err, &urlErr) || errors.As(err, &netErr) {
+		logger.ErrorWithContext(ctx, "wallet-backend transport error", "resource", resource, "address", address, "network", network, "error", err)
+		return httperror.BadGateway(fmt.Sprintf("Failed to get %s", resource), err)
+	}
+	logger.ErrorWithContext(ctx, "wallet-backend call failed", "resource", resource, "address", address, "network", network, "error", err)
+	return httperror.InternalServerError(fmt.Sprintf("Failed to get %s", resource), err)
+}

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -1,5 +1,5 @@
-// ABOUTME: HTTP handlers for the account-history endpoints (transactions / operations / state-changes).
-// ABOUTME: Shares parseRequest and translateServiceError helpers, all going through wallet-backend's GraphQL API.
+// ABOUTME: HTTP handler for the account-transactions history endpoint (transactions with embedded ops + state changes).
+// ABOUTME: Validates the request via parseRequest and maps service errors via translateServiceError, all through wallet-backend's GraphQL API.
 package handlers
 
 import (
@@ -18,12 +18,12 @@ import (
 	"github.com/stellar/freighter-backend-v2/internal/types"
 )
 
-// AccountHistoryContextTimeout caps each /accounts/{address}/{...} request
+// AccountHistoryContextTimeout caps each /accounts/{address}/transactions request
 // at 10s. Matches AccountBalancesContextTimeout.
 const AccountHistoryContextTimeout = 10 * time.Second
 
-// AccountHistoryHandler serves the three account-scoped paginated history
-// endpoints. All three methods route through parseRequest and translateServiceError.
+// AccountHistoryHandler serves the single account-scoped transactions history
+// endpoint. GetAccountTransactions routes through parseRequest and translateServiceError.
 type AccountHistoryHandler struct {
 	WalletBackendService types.WalletBackendService
 	DefaultLimit         int
@@ -129,48 +129,6 @@ func (h *AccountHistoryHandler) GetAccountTransactions(w http.ResponseWriter, r 
 	result, err := h.WalletBackendService.GetAccountTransactions(ctx, address, network, params)
 	if err != nil {
 		return translateServiceError(r.Context(), err, "account transactions", address, network)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	return response.OK(w, result)
-}
-
-// GetAccountOperations returns one page of an account's operations from
-// wallet-backend, in the PaginatedResponse[T] envelope.
-func (h *AccountHistoryHandler) GetAccountOperations(w http.ResponseWriter, r *http.Request) error {
-	ctx, cancel := context.WithTimeout(r.Context(), AccountHistoryContextTimeout)
-	defer cancel()
-
-	address, network, params, herr := h.parseRequest(r)
-	if herr != nil {
-		return herr
-	}
-
-	result, err := h.WalletBackendService.GetAccountOperations(ctx, address, network, params)
-	if err != nil {
-		return translateServiceError(r.Context(), err, "account operations", address, network)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	return response.OK(w, result)
-}
-
-// GetAccountStateChanges returns one page of an account's state changes from
-// wallet-backend, in the PaginatedResponse[T] envelope. The Data slice elements
-// are polymorphic wbtypes.StateChangeNode values (concrete type determined by
-// the upstream __typename discriminator).
-func (h *AccountHistoryHandler) GetAccountStateChanges(w http.ResponseWriter, r *http.Request) error {
-	ctx, cancel := context.WithTimeout(r.Context(), AccountHistoryContextTimeout)
-	defer cancel()
-
-	address, network, params, herr := h.parseRequest(r)
-	if herr != nil {
-		return herr
-	}
-
-	result, err := h.WalletBackendService.GetAccountStateChanges(ctx, address, network, params)
-	if err != nil {
-		return translateServiceError(r.Context(), err, "account state changes", address, network)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -64,8 +64,8 @@ func NewAccountHistoryHandler(svc types.WalletBackendService, defaultLimit, maxL
 // (always status 400) on any validation failure.
 func (h *AccountHistoryHandler) parseRequest(r *http.Request) (address, network string, p types.AccountHistoryParams, herr *httperror.HttpError) {
 	address = r.PathValue("address")
-	if _, err := strkey.Decode(strkey.VersionByteAccountID, address); err != nil {
-		return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid Stellar address %s: %s", address, err.Error()), err)
+	if !isValidStellarAddress(address) {
+		return "", "", types.AccountHistoryParams{}, httperror.BadRequest(fmt.Sprintf("invalid Stellar address %s: must be an account (G...) or contract (C...) address", address), errors.New("invalid address"))
 	}
 
 	network = r.URL.Query().Get("network")
@@ -118,6 +118,16 @@ func (h *AccountHistoryHandler) parseRequest(r *http.Request) (address, network 
 	}
 
 	return address, network, p, nil
+}
+
+// isValidStellarAddress accepts ed25519 account (G...) and contract (C...)
+// strkeys, mirroring wallet-backend's accountByAddress validation
+// (IsValidStellarAddress in wallet-backend internal/utils) so freighter
+// doesn't reject addresses the upstream can serve.
+func isValidStellarAddress(address string) bool {
+	_, errAccount := strkey.Decode(strkey.VersionByteAccountID, address)
+	_, errContract := strkey.Decode(strkey.VersionByteContract, address)
+	return errAccount == nil || errContract == nil
 }
 
 // GetAccountTransactions returns one page of an account's transactions from

--- a/internal/api/handlers/account_history.go
+++ b/internal/api/handlers/account_history.go
@@ -171,3 +171,23 @@ func (h *AccountHistoryHandler) GetAccountTransactions(w http.ResponseWriter, r 
 	w.Header().Set("Content-Type", "application/json")
 	return response.OK(w, result)
 }
+
+// GetAccountOperations returns one page of an account's operations from
+// wallet-backend, in the PaginatedResponse[T] envelope.
+func (h *AccountHistoryHandler) GetAccountOperations(w http.ResponseWriter, r *http.Request) error {
+	ctx, cancel := context.WithTimeout(r.Context(), AccountHistoryContextTimeout)
+	defer cancel()
+
+	address, network, params, herr := h.parseRequest(r)
+	if herr != nil {
+		return herr
+	}
+
+	result, err := h.WalletBackendService.GetAccountOperations(ctx, address, network, params)
+	if err != nil {
+		return translateServiceError(r.Context(), err, "account operations", address, network)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return response.OK(w, result)
+}

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -301,3 +301,155 @@ func TestGetAccountTransactions_Handler(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), `"data":[]`)
 	})
 }
+
+func TestGetAccountOperations_Handler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path 200 with paginated body", func(t *testing.T) {
+		t.Parallel()
+		nextCursor := "n"
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountOperationsResult: &types.PaginatedResponse[*wbtypes.Operation]{
+				Data: []*wbtypes.Operation{{ID: 1, OperationType: wbtypes.OperationTypePayment}},
+				Pagination: types.PaginationInfo{
+					NextCursor:  &nextCursor,
+					HasNext:     true,
+					HasPrevious: false,
+				},
+			},
+		}
+		h, err := NewAccountHistoryHandler(mockSvc, 20, 100)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountOperations(rr, req))
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var body types.PaginatedResponse[*wbtypes.Operation]
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+		require.Len(t, body.Data, 1)
+		assert.Equal(t, int64(1), body.Data[0].ID)
+		assert.True(t, body.Pagination.HasNext)
+	})
+
+	t.Run("404 when service returns ErrAccountNotFound", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: wbclient.ErrAccountNotFound}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountOperations(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusNotFound, herr.StatusCode)
+	})
+
+	t.Run("502 when service returns graphql_error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountOperations(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
+	})
+
+	t.Run("502 when service returns http_error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountOperations(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
+	})
+
+	t.Run("504 when service returns context.DeadlineExceeded", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: context.DeadlineExceeded}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountOperations(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusGatewayTimeout, herr.StatusCode)
+	})
+
+	t.Run("500 when service returns generic error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: errors.New("boom")}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountOperations(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusInternalServerError, herr.StatusCode)
+	})
+
+	t.Run("400 on invalid request (validation forwarded)", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=FUTURENET", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountOperations(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadRequest, herr.StatusCode)
+	})
+
+	t.Run("forwards parsed params to the service", func(t *testing.T) {
+		t.Parallel()
+		var (
+			gotAddress string
+			gotNetwork string
+			gotParams  types.AccountHistoryParams
+		)
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountOperationsFunc: func(_ context.Context, addr, network string, p types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.Operation], error) {
+				gotAddress = addr
+				gotNetwork = network
+				gotParams = p
+				return &types.PaginatedResponse[*wbtypes.Operation]{Data: []*wbtypes.Operation{}, Pagination: types.PaginationInfo{}}, nil
+			},
+		}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+
+		req := httptest.NewRequest(http.MethodGet, "/x?network=TESTNET&limit=5&cursor=abc&direction=prev&since=2026-01-01T00:00:00Z&until=2026-02-01T00:00:00Z", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountOperations(httptest.NewRecorder(), req))
+
+		assert.Equal(t, testAddress, gotAddress)
+		assert.Equal(t, "TESTNET", gotNetwork)
+		assert.EqualValues(t, 5, gotParams.Limit)
+		assert.Equal(t, types.PaginationDirectionPrev, gotParams.Direction)
+		require.NotNil(t, gotParams.Cursor)
+		assert.Equal(t, "abc", *gotParams.Cursor)
+		require.NotNil(t, gotParams.Since)
+		require.NotNil(t, gotParams.Until)
+	})
+
+	t.Run("empty data slice marshals as []", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountOperationsResult: &types.PaginatedResponse[*wbtypes.Operation]{
+				Data:       []*wbtypes.Operation{},
+				Pagination: types.PaginationInfo{HasNext: false, HasPrevious: false},
+			},
+		}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountOperations(rr, req))
+		assert.Contains(t, rr.Body.String(), `"data":[]`)
+	})
+}

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -23,6 +23,10 @@ import (
 
 const testAddress = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
 
+// testContractAddress is a valid contract (C...) strkey — the Meridian Pay
+// treasure-hunt contract from the dev environment config.
+const testContractAddress = "CCRIDTVINSOTNYOY6QNZ7JDCXWPOFF4SS3XXOIJIEPGVDGQ7UJP3DMJS"
+
 func TestNewAccountHistoryHandler_Validation(t *testing.T) {
 	t.Parallel()
 	mockSvc := &utils.MockWalletBackendService{}
@@ -75,6 +79,17 @@ func TestParseRequest(t *testing.T) {
 		assert.Nil(t, p.Until)
 	})
 
+	t.Run("happy path contract address", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testContractAddress)
+		addr, network, p, herr := h.parseRequest(req)
+		require.Nil(t, herr)
+		assert.Equal(t, testContractAddress, addr)
+		assert.Equal(t, "PUBLIC", network)
+		assert.EqualValues(t, 20, p.Limit) // default
+	})
+
 	t.Run("all params parsed", func(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest(http.MethodGet, "/x?network=TESTNET&limit=10&cursor=abc&direction=prev&since=2026-01-01T00:00:00Z&until=2026-02-01T00:00:00Z", nil)
@@ -107,6 +122,7 @@ func TestParseRequest(t *testing.T) {
 		{"since garbage", "network=PUBLIC&since=not-a-time", testAddress},
 		{"until garbage", "network=PUBLIC&until=not-a-time", testAddress},
 		{"since after until", "network=PUBLIC&since=2026-02-01T00:00:00Z&until=2026-01-01T00:00:00Z", testAddress},
+		{"muxed address", "network=PUBLIC", "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVAAAAAAAAAAAAAJLK"},
 	}
 	for _, tc := range rejection {
 		t.Run("rejects "+tc.name, func(t *testing.T) {

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -1,0 +1,46 @@
+// ABOUTME: Unit tests for the account-history handlers and shared translation helpers.
+// ABOUTME: Drives handlers with MockWalletBackendService to assert HTTP status, body shape, and error mapping.
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/wallet-backend/pkg/wbclient"
+
+	"github.com/stellar/freighter-backend-v2/internal/metrics"
+)
+
+func TestTranslateServiceError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"account not found -> 404", wbclient.ErrAccountNotFound, http.StatusNotFound},
+		{"ctx deadline -> 504", context.DeadlineExceeded, http.StatusGatewayTimeout},
+		{"ctx canceled -> 504", context.Canceled, http.StatusGatewayTimeout},
+		{"graphql_error -> 502", &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}, http.StatusBadGateway},
+		{"http_error -> 502", &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}, http.StatusBadGateway},
+		{"url.Error -> 502", &url.Error{Op: "Post", URL: "http://wb/graphql", Err: errors.New("dial tcp: connection refused")}, http.StatusBadGateway},
+		{"net.OpError -> 502", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}, http.StatusBadGateway},
+		{"generic -> 500", errors.New("anything else"), http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := translateServiceError(ctx, tt.err, "test resource", "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF", "PUBLIC")
+			require.NotNil(t, h)
+			assert.Equal(t, tt.wantStatus, h.StatusCode)
+		})
+	}
+}

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -68,6 +69,7 @@ func TestNewAccountHistoryHandler_Validation(t *testing.T) {
 		{"maxLimit zero", 20, 0, true},
 		{"maxLimit negative", 20, -1, true},
 		{"default greater than max", 200, 100, true},
+		{"maxLimit exceeds int32", 20, math.MaxInt32 + 1, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -4,7 +4,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"math"
 	"net/http"
@@ -16,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/pkg/wbclient"
-	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
@@ -126,33 +124,71 @@ func TestParseRequest(t *testing.T) {
 func TestGetAccountTransactions_Handler(t *testing.T) {
 	t.Parallel()
 
-	t.Run("happy path 200 with paginated body", func(t *testing.T) {
+	t.Run("happy path 200 with snake_case nested body", func(t *testing.T) {
 		t.Parallel()
 		nextCursor := "n"
 		mockSvc := &utils.MockWalletBackendService{
-			GetAccountTransactionsResult: &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{
-				Data: []*wbtypes.GraphQLTransaction{{Hash: "h1"}},
-				Pagination: types.PaginationInfo{
-					NextCursor:  &nextCursor,
-					HasNext:     true,
-					HasPrevious: false,
-				},
+			GetAccountTransactionsResult: &types.PaginatedResponse[*types.AccountTransaction]{
+				Data: []*types.AccountTransaction{{
+					Transaction: types.Transaction{Hash: "h1", FeeCharged: 100, LedgerNumber: 42},
+					Operations:  []types.Operation{{ID: 220000000000000, OperationType: "PAYMENT"}},
+					StateChanges: []types.StateChange{
+						&types.StandardBalanceChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, StandardBalanceTokenID: "native", Amount: "10"},
+					},
+				}},
+				Pagination: types.PaginationInfo{NextCursor: &nextCursor, HasNext: true},
 			},
 		}
 		h, err := NewAccountHistoryHandler(mockSvc, 20, 100)
 		require.NoError(t, err)
-
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
 		req.SetPathValue("address", testAddress)
 		require.NoError(t, h.GetAccountTransactions(rr, req))
 		assert.Equal(t, http.StatusOK, rr.Code)
+		// The full snake_case wire contract is owned by Task 2's marshaling
+		// test (TestAccountTransaction_JSONWireContract). Here we only confirm
+		// the handler emits the transaction with its embedded detail arrays and
+		// the pagination block — not every field, to avoid duplicate assertions.
+		body := rr.Body.String()
+		assert.Contains(t, body, `"hash":"h1"`)
+		assert.Contains(t, body, `"operations":`)
+		assert.Contains(t, body, `"state_changes":`)
+		assert.Contains(t, body, `"has_next":true`)
+	})
 
-		var body types.PaginatedResponse[*wbtypes.GraphQLTransaction]
-		require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
-		require.Len(t, body.Data, 1)
-		assert.Equal(t, "h1", body.Data[0].Hash)
-		assert.True(t, body.Pagination.HasNext)
+	t.Run("empty details marshal as []", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountTransactionsResult: &types.PaginatedResponse[*types.AccountTransaction]{
+				Data: []*types.AccountTransaction{{
+					Transaction:  types.Transaction{Hash: "h1"},
+					Operations:   []types.Operation{},
+					StateChanges: []types.StateChange{},
+				}},
+				Pagination: types.PaginationInfo{},
+			},
+		}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountTransactions(rr, req))
+		assert.Contains(t, rr.Body.String(), `"operations":[]`)
+		assert.Contains(t, rr.Body.String(), `"state_changes":[]`)
+	})
+
+	t.Run("empty data slice marshals as []", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountTransactionsResult: &types.PaginatedResponse[*types.AccountTransaction]{Data: []*types.AccountTransaction{}, Pagination: types.PaginationInfo{}},
+		}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountTransactions(rr, req))
+		assert.Contains(t, rr.Body.String(), `"data":[]`)
 	})
 
 	t.Run("404 when service returns ErrAccountNotFound", func(t *testing.T) {
@@ -235,11 +271,11 @@ func TestGetAccountTransactions_Handler(t *testing.T) {
 			gotParams  types.AccountHistoryParams
 		)
 		mockSvc := &utils.MockWalletBackendService{
-			GetAccountTransactionsFunc: func(_ context.Context, addr, network string, p types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.GraphQLTransaction], error) {
+			GetAccountTransactionsFunc: func(_ context.Context, addr, network string, p types.AccountHistoryParams) (*types.PaginatedResponse[*types.AccountTransaction], error) {
 				gotAddress = addr
 				gotNetwork = network
 				gotParams = p
-				return &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{Data: []*wbtypes.GraphQLTransaction{}, Pagination: types.PaginationInfo{}}, nil
+				return &types.PaginatedResponse[*types.AccountTransaction]{Data: []*types.AccountTransaction{}, Pagination: types.PaginationInfo{}}, nil
 			},
 		}
 		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
@@ -256,326 +292,5 @@ func TestGetAccountTransactions_Handler(t *testing.T) {
 		assert.Equal(t, "abc", *gotParams.Cursor)
 		require.NotNil(t, gotParams.Since)
 		require.NotNil(t, gotParams.Until)
-	})
-
-	t.Run("empty data slice marshals as []", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{
-			GetAccountTransactionsResult: &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{
-				Data:       []*wbtypes.GraphQLTransaction{},
-				Pagination: types.PaginationInfo{HasNext: false, HasPrevious: false},
-			},
-		}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		require.NoError(t, h.GetAccountTransactions(rr, req))
-		assert.Contains(t, rr.Body.String(), `"data":[]`)
-	})
-}
-
-func TestGetAccountOperations_Handler(t *testing.T) {
-	t.Parallel()
-
-	t.Run("happy path 200 with paginated body", func(t *testing.T) {
-		t.Parallel()
-		nextCursor := "n"
-		mockSvc := &utils.MockWalletBackendService{
-			GetAccountOperationsResult: &types.PaginatedResponse[*wbtypes.Operation]{
-				Data: []*wbtypes.Operation{{ID: 1, OperationType: wbtypes.OperationTypePayment}},
-				Pagination: types.PaginationInfo{
-					NextCursor:  &nextCursor,
-					HasNext:     true,
-					HasPrevious: false,
-				},
-			},
-		}
-		h, err := NewAccountHistoryHandler(mockSvc, 20, 100)
-		require.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		require.NoError(t, h.GetAccountOperations(rr, req))
-		assert.Equal(t, http.StatusOK, rr.Code)
-
-		var body types.PaginatedResponse[*wbtypes.Operation]
-		require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
-		require.Len(t, body.Data, 1)
-		assert.Equal(t, int64(1), body.Data[0].ID)
-		assert.True(t, body.Pagination.HasNext)
-	})
-
-	t.Run("404 when service returns ErrAccountNotFound", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: wbclient.ErrAccountNotFound}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountOperations(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusNotFound, herr.StatusCode)
-	})
-
-	t.Run("502 when service returns graphql_error", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountOperations(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
-	})
-
-	t.Run("502 when service returns http_error", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountOperations(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
-	})
-
-	t.Run("504 when service returns context.DeadlineExceeded", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: context.DeadlineExceeded}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountOperations(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusGatewayTimeout, herr.StatusCode)
-	})
-
-	t.Run("500 when service returns generic error", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountOperationsError: errors.New("boom")}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountOperations(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusInternalServerError, herr.StatusCode)
-	})
-
-	t.Run("400 on invalid request (validation forwarded)", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=FUTURENET", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountOperations(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusBadRequest, herr.StatusCode)
-	})
-
-	t.Run("forwards parsed params to the service", func(t *testing.T) {
-		t.Parallel()
-		var (
-			gotAddress string
-			gotNetwork string
-			gotParams  types.AccountHistoryParams
-		)
-		mockSvc := &utils.MockWalletBackendService{
-			GetAccountOperationsFunc: func(_ context.Context, addr, network string, p types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.Operation], error) {
-				gotAddress = addr
-				gotNetwork = network
-				gotParams = p
-				return &types.PaginatedResponse[*wbtypes.Operation]{Data: []*wbtypes.Operation{}, Pagination: types.PaginationInfo{}}, nil
-			},
-		}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-
-		req := httptest.NewRequest(http.MethodGet, "/x?network=TESTNET&limit=5&cursor=abc&direction=prev&since=2026-01-01T00:00:00Z&until=2026-02-01T00:00:00Z", nil)
-		req.SetPathValue("address", testAddress)
-		require.NoError(t, h.GetAccountOperations(httptest.NewRecorder(), req))
-
-		assert.Equal(t, testAddress, gotAddress)
-		assert.Equal(t, "TESTNET", gotNetwork)
-		assert.EqualValues(t, 5, gotParams.Limit)
-		assert.Equal(t, types.PaginationDirectionPrev, gotParams.Direction)
-		require.NotNil(t, gotParams.Cursor)
-		assert.Equal(t, "abc", *gotParams.Cursor)
-		require.NotNil(t, gotParams.Since)
-		require.NotNil(t, gotParams.Until)
-	})
-
-	t.Run("empty data slice marshals as []", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{
-			GetAccountOperationsResult: &types.PaginatedResponse[*wbtypes.Operation]{
-				Data:       []*wbtypes.Operation{},
-				Pagination: types.PaginationInfo{HasNext: false, HasPrevious: false},
-			},
-		}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		require.NoError(t, h.GetAccountOperations(rr, req))
-		assert.Contains(t, rr.Body.String(), `"data":[]`)
-	})
-}
-
-func TestGetAccountStateChanges_Handler(t *testing.T) {
-	t.Parallel()
-
-	t.Run("happy path 200 with paginated body", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{
-			GetAccountStateChangesResult: &types.PaginatedResponse[wbtypes.StateChangeNode]{
-				Data: []wbtypes.StateChangeNode{
-					&wbtypes.StandardBalanceChange{
-						BaseStateChangeFields: wbtypes.BaseStateChangeFields{
-							Type:   wbtypes.StateChangeCategoryBalance,
-							Reason: wbtypes.StateChangeReasonCredit,
-						},
-						TokenID: "native",
-						Amount:  "100",
-					},
-				},
-				Pagination: types.PaginationInfo{HasNext: false, HasPrevious: false},
-			},
-		}
-		h, err := NewAccountHistoryHandler(mockSvc, 20, 100)
-		require.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		require.NoError(t, h.GetAccountStateChanges(rr, req))
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Contains(t, rr.Body.String(), `"type":"BALANCE"`)
-		assert.Contains(t, rr.Body.String(), `"reason":"CREDIT"`)
-		assert.Contains(t, rr.Body.String(), `"has_next":false`)
-	})
-
-	t.Run("404 when service returns ErrAccountNotFound", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: wbclient.ErrAccountNotFound}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusNotFound, herr.StatusCode)
-	})
-
-	t.Run("502 when service returns graphql_error", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
-	})
-
-	t.Run("502 when service returns http_error", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
-	})
-
-	t.Run("504 when service returns context.DeadlineExceeded", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: context.DeadlineExceeded}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusGatewayTimeout, herr.StatusCode)
-	})
-
-	t.Run("500 when service returns generic error", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: errors.New("boom")}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusInternalServerError, herr.StatusCode)
-	})
-
-	t.Run("400 on invalid request (validation forwarded)", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		req := httptest.NewRequest(http.MethodGet, "/x?network=FUTURENET", nil)
-		req.SetPathValue("address", testAddress)
-		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
-		var herr *httperror.HttpError
-		require.True(t, errors.As(err, &herr))
-		assert.Equal(t, http.StatusBadRequest, herr.StatusCode)
-	})
-
-	t.Run("forwards parsed params to the service", func(t *testing.T) {
-		t.Parallel()
-		var (
-			gotAddress string
-			gotNetwork string
-			gotParams  types.AccountHistoryParams
-		)
-		mockSvc := &utils.MockWalletBackendService{
-			GetAccountStateChangesFunc: func(_ context.Context, addr, network string, p types.AccountHistoryParams) (*types.PaginatedResponse[wbtypes.StateChangeNode], error) {
-				gotAddress = addr
-				gotNetwork = network
-				gotParams = p
-				return &types.PaginatedResponse[wbtypes.StateChangeNode]{Data: []wbtypes.StateChangeNode{}, Pagination: types.PaginationInfo{}}, nil
-			},
-		}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-
-		req := httptest.NewRequest(http.MethodGet, "/x?network=TESTNET&limit=5&cursor=abc&direction=prev&since=2026-01-01T00:00:00Z&until=2026-02-01T00:00:00Z", nil)
-		req.SetPathValue("address", testAddress)
-		require.NoError(t, h.GetAccountStateChanges(httptest.NewRecorder(), req))
-
-		assert.Equal(t, testAddress, gotAddress)
-		assert.Equal(t, "TESTNET", gotNetwork)
-		assert.EqualValues(t, 5, gotParams.Limit)
-		assert.Equal(t, types.PaginationDirectionPrev, gotParams.Direction)
-		require.NotNil(t, gotParams.Cursor)
-		assert.Equal(t, "abc", *gotParams.Cursor)
-		require.NotNil(t, gotParams.Since)
-		require.NotNil(t, gotParams.Until)
-	})
-
-	t.Run("empty data slice marshals as []", func(t *testing.T) {
-		t.Parallel()
-		mockSvc := &utils.MockWalletBackendService{
-			GetAccountStateChangesResult: &types.PaginatedResponse[wbtypes.StateChangeNode]{
-				Data:       []wbtypes.StateChangeNode{},
-				Pagination: types.PaginationInfo{HasNext: false, HasPrevious: false},
-			},
-		}
-		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
-		req.SetPathValue("address", testAddress)
-		require.NoError(t, h.GetAccountStateChanges(rr, req))
-		assert.Contains(t, rr.Body.String(), `"data":[]`)
 	})
 }

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -453,3 +453,156 @@ func TestGetAccountOperations_Handler(t *testing.T) {
 		assert.Contains(t, rr.Body.String(), `"data":[]`)
 	})
 }
+
+func TestGetAccountStateChanges_Handler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path 200 with paginated body", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountStateChangesResult: &types.PaginatedResponse[wbtypes.StateChangeNode]{
+				Data: []wbtypes.StateChangeNode{
+					&wbtypes.StandardBalanceChange{
+						BaseStateChangeFields: wbtypes.BaseStateChangeFields{
+							Type:   wbtypes.StateChangeCategoryBalance,
+							Reason: wbtypes.StateChangeReasonCredit,
+						},
+						TokenID: "native",
+						Amount:  "100",
+					},
+				},
+				Pagination: types.PaginationInfo{HasNext: false, HasPrevious: false},
+			},
+		}
+		h, err := NewAccountHistoryHandler(mockSvc, 20, 100)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountStateChanges(rr, req))
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), `"type":"BALANCE"`)
+		assert.Contains(t, rr.Body.String(), `"reason":"CREDIT"`)
+		assert.Contains(t, rr.Body.String(), `"has_next":false`)
+	})
+
+	t.Run("404 when service returns ErrAccountNotFound", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: wbclient.ErrAccountNotFound}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusNotFound, herr.StatusCode)
+	})
+
+	t.Run("502 when service returns graphql_error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
+	})
+
+	t.Run("502 when service returns http_error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
+	})
+
+	t.Run("504 when service returns context.DeadlineExceeded", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: context.DeadlineExceeded}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusGatewayTimeout, herr.StatusCode)
+	})
+
+	t.Run("500 when service returns generic error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountStateChangesError: errors.New("boom")}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusInternalServerError, herr.StatusCode)
+	})
+
+	t.Run("400 on invalid request (validation forwarded)", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=FUTURENET", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountStateChanges(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadRequest, herr.StatusCode)
+	})
+
+	t.Run("forwards parsed params to the service", func(t *testing.T) {
+		t.Parallel()
+		var (
+			gotAddress string
+			gotNetwork string
+			gotParams  types.AccountHistoryParams
+		)
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountStateChangesFunc: func(_ context.Context, addr, network string, p types.AccountHistoryParams) (*types.PaginatedResponse[wbtypes.StateChangeNode], error) {
+				gotAddress = addr
+				gotNetwork = network
+				gotParams = p
+				return &types.PaginatedResponse[wbtypes.StateChangeNode]{Data: []wbtypes.StateChangeNode{}, Pagination: types.PaginationInfo{}}, nil
+			},
+		}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+
+		req := httptest.NewRequest(http.MethodGet, "/x?network=TESTNET&limit=5&cursor=abc&direction=prev&since=2026-01-01T00:00:00Z&until=2026-02-01T00:00:00Z", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountStateChanges(httptest.NewRecorder(), req))
+
+		assert.Equal(t, testAddress, gotAddress)
+		assert.Equal(t, "TESTNET", gotNetwork)
+		assert.EqualValues(t, 5, gotParams.Limit)
+		assert.Equal(t, types.PaginationDirectionPrev, gotParams.Direction)
+		require.NotNil(t, gotParams.Cursor)
+		assert.Equal(t, "abc", *gotParams.Cursor)
+		require.NotNil(t, gotParams.Since)
+		require.NotNil(t, gotParams.Until)
+	})
+
+	t.Run("empty data slice marshals as []", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountStateChangesResult: &types.PaginatedResponse[wbtypes.StateChangeNode]{
+				Data:       []wbtypes.StateChangeNode{},
+				Pagination: types.PaginationInfo{HasNext: false, HasPrevious: false},
+			},
+		}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountStateChanges(rr, req))
+		assert.Contains(t, rr.Body.String(), `"data":[]`)
+	})
+}

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -4,6 +4,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -16,7 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/pkg/wbclient"
+	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
 
+	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/types"
 	"github.com/stellar/freighter-backend-v2/internal/utils"
@@ -145,4 +148,156 @@ func TestParseRequest(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, herr.StatusCode)
 		})
 	}
+}
+
+func TestGetAccountTransactions_Handler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path 200 with paginated body", func(t *testing.T) {
+		t.Parallel()
+		nextCursor := "n"
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountTransactionsResult: &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{
+				Data: []*wbtypes.GraphQLTransaction{{Hash: "h1"}},
+				Pagination: types.PaginationInfo{
+					NextCursor:  &nextCursor,
+					HasNext:     true,
+					HasPrevious: false,
+				},
+			},
+		}
+		h, err := NewAccountHistoryHandler(mockSvc, 20, 100)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountTransactions(rr, req))
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var body types.PaginatedResponse[*wbtypes.GraphQLTransaction]
+		require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+		require.Len(t, body.Data, 1)
+		assert.Equal(t, "h1", body.Data[0].Hash)
+		assert.True(t, body.Pagination.HasNext)
+	})
+
+	t.Run("404 when service returns ErrAccountNotFound", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountTransactionsError: wbclient.ErrAccountNotFound}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountTransactions(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusNotFound, herr.StatusCode)
+	})
+
+	t.Run("502 when service returns graphql_error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountTransactionsError: &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountTransactions(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
+	})
+
+	t.Run("502 when service returns http_error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountTransactionsError: &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountTransactions(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadGateway, herr.StatusCode)
+	})
+
+	t.Run("504 when service returns context.DeadlineExceeded", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountTransactionsError: context.DeadlineExceeded}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountTransactions(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusGatewayTimeout, herr.StatusCode)
+	})
+
+	t.Run("500 when service returns generic error", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{GetAccountTransactionsError: errors.New("boom")}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountTransactions(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusInternalServerError, herr.StatusCode)
+	})
+
+	t.Run("400 on invalid request (validation forwarded)", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		req := httptest.NewRequest(http.MethodGet, "/x?network=FUTURENET", nil)
+		req.SetPathValue("address", testAddress)
+		err := h.GetAccountTransactions(httptest.NewRecorder(), req)
+		var herr *httperror.HttpError
+		require.True(t, errors.As(err, &herr))
+		assert.Equal(t, http.StatusBadRequest, herr.StatusCode)
+	})
+
+	t.Run("forwards parsed params to the service", func(t *testing.T) {
+		t.Parallel()
+		var (
+			gotAddress string
+			gotNetwork string
+			gotParams  types.AccountHistoryParams
+		)
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountTransactionsFunc: func(_ context.Context, addr, network string, p types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.GraphQLTransaction], error) {
+				gotAddress = addr
+				gotNetwork = network
+				gotParams = p
+				return &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{Data: []*wbtypes.GraphQLTransaction{}, Pagination: types.PaginationInfo{}}, nil
+			},
+		}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+
+		req := httptest.NewRequest(http.MethodGet, "/x?network=TESTNET&limit=5&cursor=abc&direction=prev&since=2026-01-01T00:00:00Z&until=2026-02-01T00:00:00Z", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountTransactions(httptest.NewRecorder(), req))
+
+		assert.Equal(t, testAddress, gotAddress)
+		assert.Equal(t, "TESTNET", gotNetwork)
+		assert.EqualValues(t, 5, gotParams.Limit)
+		assert.Equal(t, types.PaginationDirectionPrev, gotParams.Direction)
+		require.NotNil(t, gotParams.Cursor)
+		assert.Equal(t, "abc", *gotParams.Cursor)
+		require.NotNil(t, gotParams.Since)
+		require.NotNil(t, gotParams.Until)
+	})
+
+	t.Run("empty data slice marshals as []", func(t *testing.T) {
+		t.Parallel()
+		mockSvc := &utils.MockWalletBackendService{
+			GetAccountTransactionsResult: &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{
+				Data:       []*wbtypes.GraphQLTransaction{},
+				Pagination: types.PaginationInfo{HasNext: false, HasPrevious: false},
+			},
+		}
+		h, _ := NewAccountHistoryHandler(mockSvc, 20, 100)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		require.NoError(t, h.GetAccountTransactions(rr, req))
+		assert.Contains(t, rr.Body.String(), `"data":[]`)
+	})
 }

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -16,7 +17,11 @@ import (
 	"github.com/stellar/wallet-backend/pkg/wbclient"
 
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
+	"github.com/stellar/freighter-backend-v2/internal/types"
+	"github.com/stellar/freighter-backend-v2/internal/utils"
 )
+
+const testAddress = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
 
 func TestTranslateServiceError(t *testing.T) {
 	t.Parallel()
@@ -38,9 +43,103 @@ func TestTranslateServiceError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			h := translateServiceError(ctx, tt.err, "test resource", "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF", "PUBLIC")
+			h := translateServiceError(ctx, tt.err, "test resource", testAddress, "PUBLIC")
 			require.NotNil(t, h)
 			assert.Equal(t, tt.wantStatus, h.StatusCode)
+		})
+	}
+}
+
+func TestNewAccountHistoryHandler_Validation(t *testing.T) {
+	t.Parallel()
+	mockSvc := &utils.MockWalletBackendService{}
+	cases := []struct {
+		name     string
+		def, max int
+		wantErr  bool
+	}{
+		{"valid", 20, 100, false},
+		{"defaultLimit zero", 0, 100, true},
+		{"defaultLimit negative", -1, 100, true},
+		{"maxLimit zero", 20, 0, true},
+		{"maxLimit negative", 20, -1, true},
+		{"default greater than max", 200, 100, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h, err := NewAccountHistoryHandler(mockSvc, tc.def, tc.max)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, h)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, h)
+			}
+		})
+	}
+}
+
+func TestParseRequest(t *testing.T) {
+	t.Parallel()
+	mockSvc := &utils.MockWalletBackendService{}
+	h, err := NewAccountHistoryHandler(mockSvc, 20, 100)
+	require.NoError(t, err)
+
+	t.Run("happy path defaults", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=PUBLIC", nil)
+		req.SetPathValue("address", testAddress)
+		addr, network, p, herr := h.parseRequest(req)
+		require.Nil(t, herr)
+		assert.Equal(t, testAddress, addr)
+		assert.Equal(t, "PUBLIC", network)
+		assert.EqualValues(t, 20, p.Limit) // default
+		assert.Equal(t, types.PaginationDirectionNext, p.Direction)
+		assert.Nil(t, p.Cursor)
+		assert.Nil(t, p.Since)
+		assert.Nil(t, p.Until)
+	})
+
+	t.Run("all params parsed", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/x?network=TESTNET&limit=10&cursor=abc&direction=prev&since=2026-01-01T00:00:00Z&until=2026-02-01T00:00:00Z", nil)
+		req.SetPathValue("address", testAddress)
+		addr, network, p, herr := h.parseRequest(req)
+		require.Nil(t, herr)
+		assert.Equal(t, testAddress, addr)
+		assert.Equal(t, "TESTNET", network)
+		assert.EqualValues(t, 10, p.Limit)
+		assert.Equal(t, types.PaginationDirectionPrev, p.Direction)
+		require.NotNil(t, p.Cursor)
+		assert.Equal(t, "abc", *p.Cursor)
+		require.NotNil(t, p.Since)
+		require.NotNil(t, p.Until)
+	})
+
+	rejection := []struct {
+		name, query, address string
+	}{
+		{"invalid address", "network=PUBLIC", "not-a-stellar-address"},
+		{"missing network", "", testAddress},
+		{"invalid network futurenet", "network=FUTURENET", testAddress},
+		{"invalid network garbage", "network=foo", testAddress},
+		{"limit zero", "network=PUBLIC&limit=0", testAddress},
+		{"limit too big", "network=PUBLIC&limit=101", testAddress},
+		{"limit non-integer", "network=PUBLIC&limit=abc", testAddress},
+		{"direction garbage", "network=PUBLIC&direction=sideways", testAddress},
+		{"since garbage", "network=PUBLIC&since=not-a-time", testAddress},
+		{"until garbage", "network=PUBLIC&until=not-a-time", testAddress},
+		{"since after until", "network=PUBLIC&since=2026-02-01T00:00:00Z&until=2026-01-01T00:00:00Z", testAddress},
+	}
+	for _, tc := range rejection {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodGet, "/x?"+tc.query, nil)
+			req.SetPathValue("address", tc.address)
+			_, _, _, herr := h.parseRequest(req)
+			require.NotNil(t, herr)
+			assert.Equal(t, http.StatusBadRequest, herr.StatusCode)
 		})
 	}
 }

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -115,6 +116,8 @@ func TestParseRequest(t *testing.T) {
 		assert.Equal(t, "abc", *p.Cursor)
 		require.NotNil(t, p.Since)
 		require.NotNil(t, p.Until)
+		assert.Equal(t, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), *p.Since)
+		assert.Equal(t, time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), *p.Until)
 	})
 
 	rejection := []struct {

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -5,7 +5,6 @@ package handlers
 import (
 	"context"
 	"errors"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,7 +37,7 @@ func TestNewAccountHistoryHandler_Validation(t *testing.T) {
 		{"maxLimit zero", 20, 0, true},
 		{"maxLimit negative", 20, -1, true},
 		{"default greater than max", 200, 100, true},
-		{"maxLimit exceeds int32", 20, math.MaxInt32 + 1, true},
+		{"maxLimit exceeds upstream cap", 20, 101, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/handlers/account_history_test.go
+++ b/internal/api/handlers/account_history_test.go
@@ -7,10 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"math"
-	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
@@ -27,33 +25,6 @@ import (
 )
 
 const testAddress = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
-
-func TestTranslateServiceError(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	tests := []struct {
-		name       string
-		err        error
-		wantStatus int
-	}{
-		{"account not found -> 404", wbclient.ErrAccountNotFound, http.StatusNotFound},
-		{"ctx deadline -> 504", context.DeadlineExceeded, http.StatusGatewayTimeout},
-		{"ctx canceled -> 504", context.Canceled, http.StatusGatewayTimeout},
-		{"graphql_error -> 502", &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}, http.StatusBadGateway},
-		{"http_error -> 502", &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}, http.StatusBadGateway},
-		{"url.Error -> 502", &url.Error{Op: "Post", URL: "http://wb/graphql", Err: errors.New("dial tcp: connection refused")}, http.StatusBadGateway},
-		{"net.OpError -> 502", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}, http.StatusBadGateway},
-		{"generic -> 500", errors.New("anything else"), http.StatusInternalServerError},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			h := translateServiceError(ctx, tt.err, "test resource", testAddress, "PUBLIC")
-			require.NotNil(t, h)
-			assert.Equal(t, tt.wantStatus, h.StatusCode)
-		})
-	}
-}
 
 func TestNewAccountHistoryHandler_Validation(t *testing.T) {
 	t.Parallel()

--- a/internal/api/handlers/utils.go
+++ b/internal/api/handlers/utils.go
@@ -17,6 +17,15 @@ func isValidNetwork(network string) bool {
 	return network == types.PUBLIC || network == types.TESTNET || network == types.FUTURENET
 }
 
+// isValidWalletBackendNetwork reports whether network is one of the values
+// freighter-backend has a wallet-backend client configured for. WalletBackendConfig
+// only carries pubnet and testnet URL/signing-key fields, so FUTURENET (which is
+// otherwise a valid Stellar network in this codebase) is intentionally rejected
+// to prevent silent fall-through to the pubnet client.
+func isValidWalletBackendNetwork(network string) bool {
+	return network == types.PUBLIC || network == types.TESTNET
+}
+
 type collection struct {
 	Name   string `json:"name"`
 	Symbol string `json:"symbol"`

--- a/internal/api/handlers/utils.go
+++ b/internal/api/handlers/utils.go
@@ -2,13 +2,20 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"strconv"
 
 	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stellar/wallet-backend/pkg/wbclient"
 
+	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
+	"github.com/stellar/freighter-backend-v2/internal/logger"
+	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/types"
 	"github.com/stellar/freighter-backend-v2/internal/utils"
 )
@@ -20,6 +27,39 @@ import (
 // to prevent silent fall-through to the pubnet client.
 func isValidWalletBackendNetwork(network string) bool {
 	return network == types.PUBLIC || network == types.TESTNET
+}
+
+// translateServiceError maps a service-layer error to a typed HttpError per
+// the spec's REST-honest mapping. Logs all non-404 errors with context;
+// account-not-found is a normal client outcome and is not logged.
+//
+// Status mapping:
+//   - wbclient.ErrAccountNotFound       -> 404
+//   - context.DeadlineExceeded/Canceled -> 504
+//   - *metrics.UpstreamError (any Kind) -> 502 (graphql_error, http_error)
+//   - *url.Error / *net.OpError         -> 502 (transport / DNS / dial)
+//   - anything else                     -> 500
+func translateServiceError(ctx context.Context, err error, resource, address, network string) *httperror.HttpError {
+	switch {
+	case errors.Is(err, wbclient.ErrAccountNotFound):
+		return httperror.NotFound(fmt.Sprintf("%s not found", resource), err)
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		logger.ErrorWithContext(ctx, "wallet-backend call timed out", "resource", resource, "address", address, "network", network, "error", err)
+		return httperror.GatewayTimeout(fmt.Sprintf("Failed to get %s", resource), err)
+	}
+	var upErr *metrics.UpstreamError
+	if errors.As(err, &upErr) {
+		logger.ErrorWithContext(ctx, "wallet-backend upstream error", "resource", resource, "address", address, "network", network, "kind", upErr.Kind, "code", upErr.Code, "error", err)
+		return httperror.BadGateway(fmt.Sprintf("Failed to get %s", resource), err)
+	}
+	var urlErr *url.Error
+	var netErr *net.OpError
+	if errors.As(err, &urlErr) || errors.As(err, &netErr) {
+		logger.ErrorWithContext(ctx, "wallet-backend transport error", "resource", resource, "address", address, "network", network, "error", err)
+		return httperror.BadGateway(fmt.Sprintf("Failed to get %s", resource), err)
+	}
+	logger.ErrorWithContext(ctx, "wallet-backend call failed", "resource", resource, "address", address, "network", network, "error", err)
+	return httperror.InternalServerError(fmt.Sprintf("Failed to get %s", resource), err)
 }
 
 type collection struct {

--- a/internal/api/handlers/utils.go
+++ b/internal/api/handlers/utils.go
@@ -13,10 +13,6 @@ import (
 	"github.com/stellar/freighter-backend-v2/internal/utils"
 )
 
-func isValidNetwork(network string) bool {
-	return network == types.PUBLIC || network == types.TESTNET || network == types.FUTURENET
-}
-
 // isValidWalletBackendNetwork reports whether network is one of the values
 // freighter-backend has a wallet-backend client configured for. WalletBackendConfig
 // only carries pubnet and testnet URL/signing-key fields, so FUTURENET (which is

--- a/internal/api/handlers/utils.go
+++ b/internal/api/handlers/utils.go
@@ -35,7 +35,8 @@ func isValidWalletBackendNetwork(network string) bool {
 //
 // Status mapping:
 //   - wbclient.ErrAccountNotFound       -> 404
-//   - context.DeadlineExceeded/Canceled -> 504
+//   - context.DeadlineExceeded          -> 504 (server-side timeout)
+//   - context.Canceled                  -> 503 (client disconnect / parent abort)
 //   - *metrics.UpstreamError (any Kind) -> 502 (graphql_error, http_error)
 //   - *url.Error / *net.OpError         -> 502 (transport / DNS / dial)
 //   - anything else                     -> 500
@@ -43,9 +44,12 @@ func translateServiceError(ctx context.Context, err error, resource, address, ne
 	switch {
 	case errors.Is(err, wbclient.ErrAccountNotFound):
 		return httperror.NotFound(fmt.Sprintf("%s not found", resource), err)
-	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+	case errors.Is(err, context.DeadlineExceeded):
 		logger.ErrorWithContext(ctx, "wallet-backend call timed out", "resource", resource, "address", address, "network", network, "error", err)
 		return httperror.GatewayTimeout(fmt.Sprintf("Failed to get %s", resource), err)
+	case errors.Is(err, context.Canceled):
+		logger.ErrorWithContext(ctx, "wallet-backend call canceled by client", "resource", resource, "address", address, "network", network, "error", err)
+		return httperror.ServiceUnavailable(fmt.Sprintf("Failed to get %s", resource), err)
 	}
 	var upErr *metrics.UpstreamError
 	if errors.As(err, &upErr) {

--- a/internal/api/handlers/utils_test.go
+++ b/internal/api/handlers/utils_test.go
@@ -192,7 +192,7 @@ func TestTranslateServiceError(t *testing.T) {
 	}{
 		{"account not found -> 404", wbclient.ErrAccountNotFound, http.StatusNotFound},
 		{"ctx deadline -> 504", context.DeadlineExceeded, http.StatusGatewayTimeout},
-		{"ctx canceled -> 504", context.Canceled, http.StatusGatewayTimeout},
+		{"ctx canceled -> 503", context.Canceled, http.StatusServiceUnavailable},
 		{"graphql_error -> 502", &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}, http.StatusBadGateway},
 		{"http_error -> 502", &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}, http.StatusBadGateway},
 		{"url.Error -> 502", &url.Error{Op: "Post", URL: "http://wb/graphql", Err: errors.New("dial tcp: connection refused")}, http.StatusBadGateway},

--- a/internal/api/handlers/utils_test.go
+++ b/internal/api/handlers/utils_test.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/alitto/pond/v2"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stellar/wallet-backend/pkg/wbclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/utils"
 )
 
@@ -173,6 +178,33 @@ func TestIsValidWalletBackendNetwork(t *testing.T) {
 		t.Run(tt.network, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tt.want, isValidWalletBackendNetwork(tt.network))
+		})
+	}
+}
+
+func TestTranslateServiceError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"account not found -> 404", wbclient.ErrAccountNotFound, http.StatusNotFound},
+		{"ctx deadline -> 504", context.DeadlineExceeded, http.StatusGatewayTimeout},
+		{"ctx canceled -> 504", context.Canceled, http.StatusGatewayTimeout},
+		{"graphql_error -> 502", &metrics.UpstreamError{Kind: "graphql_error", Err: errors.New("schema bug")}, http.StatusBadGateway},
+		{"http_error -> 502", &metrics.UpstreamError{Kind: "http_error", Code: 503, Err: errors.New("upstream down")}, http.StatusBadGateway},
+		{"url.Error -> 502", &url.Error{Op: "Post", URL: "http://wb/graphql", Err: errors.New("dial tcp: connection refused")}, http.StatusBadGateway},
+		{"net.OpError -> 502", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}, http.StatusBadGateway},
+		{"generic -> 500", errors.New("anything else"), http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := translateServiceError(ctx, tt.err, "test resource", "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF", "PUBLIC")
+			require.NotNil(t, h)
+			assert.Equal(t, tt.wantStatus, h.StatusCode)
 		})
 	}
 }

--- a/internal/api/handlers/utils_test.go
+++ b/internal/api/handlers/utils_test.go
@@ -156,3 +156,23 @@ func TestFetchOwnerTokens_NonVecResponse(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "expected SCV_VEC result")
 }
+
+func TestIsValidWalletBackendNetwork(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		network string
+		want    bool
+	}{
+		{"PUBLIC", true},
+		{"TESTNET", true},
+		{"FUTURENET", false},
+		{"", false},
+		{"public", false}, // case-sensitive — matches existing isValidNetwork behavior
+	}
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isValidWalletBackendNetwork(tt.network))
+		})
+	}
+}

--- a/internal/api/httperror/status_codes.go
+++ b/internal/api/httperror/status_codes.go
@@ -77,6 +77,16 @@ func ServiceUnavailablef(format string, args ...interface{}) *HttpError {
 	return NewHttpError(fmt.Sprintf(format, args...), nil, http.StatusServiceUnavailable, nil)
 }
 
+// BadGateway creates a 502 Bad Gateway error
+func BadGateway(message string, err error) *HttpError {
+	return NewHttpError(message, err, http.StatusBadGateway, nil)
+}
+
+// GatewayTimeout creates a 504 Gateway Timeout error
+func GatewayTimeout(message string, err error) *HttpError {
+	return NewHttpError(message, err, http.StatusGatewayTimeout, nil)
+}
+
 // WithExtras adds extra data to any HttpError
 func WithExtras(err *HttpError, extras map[string]interface{}) *HttpError {
 	err.Extras = extras

--- a/internal/api/httperror/status_codes_test.go
+++ b/internal/api/httperror/status_codes_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStatusCodeHelpers(t *testing.T) {
@@ -143,4 +144,22 @@ func TestWithExtras(t *testing.T) {
 	assert.Equal(t, extras, errWithExtras.Extras)
 	assert.Equal(t, err.StatusCode, errWithExtras.StatusCode)
 	assert.Equal(t, err.Message, errWithExtras.Message)
+}
+
+func TestBadGateway(t *testing.T) {
+	root := errors.New("upstream failed")
+	h := BadGateway("upstream unavailable", root)
+	require.NotNil(t, h)
+	assert.Equal(t, "upstream unavailable", h.Message)
+	assert.Equal(t, root, h.Err)
+	assert.Equal(t, http.StatusBadGateway, h.StatusCode)
+}
+
+func TestGatewayTimeout(t *testing.T) {
+	root := errors.New("ctx deadline exceeded")
+	h := GatewayTimeout("upstream timed out", root)
+	require.NotNil(t, h)
+	assert.Equal(t, "upstream timed out", h.Message)
+	assert.Equal(t, root, h.Err)
+	assert.Equal(t, http.StatusGatewayTimeout, h.StatusCode)
 }

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -123,8 +123,6 @@ func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
 		return nil, fmt.Errorf("init account-history handler: %w", err)
 	}
 	mux.HandleFunc("GET /api/v1/accounts/{address}/transactions", handlers.CustomHandler(accountHistoryHandler.GetAccountTransactions))
-	mux.HandleFunc("GET /api/v1/accounts/{address}/operations", handlers.CustomHandler(accountHistoryHandler.GetAccountOperations))
-	mux.HandleFunc("GET /api/v1/accounts/{address}/state-changes", handlers.CustomHandler(accountHistoryHandler.GetAccountStateChanges))
 
 	return mux, nil
 }

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -110,6 +110,18 @@ func (s *ApiServer) initHandlers() *http.ServeMux {
 	accountBalancesHandler := handlers.NewAccountBalancesHandler(s.walletBackendService, s.cfg.AppConfig.MaxBalanceAddresses)
 	mux.HandleFunc("POST /api/v1/accounts/balances", handlers.CustomHandler(accountBalancesHandler.GetAccountBalances))
 
+	accountHistoryHandler, err := handlers.NewAccountHistoryHandler(
+		s.walletBackendService,
+		s.cfg.AppConfig.AccountHistoryDefaultLimit,
+		s.cfg.AppConfig.AccountHistoryMaxLimit,
+	)
+	if err != nil {
+		panic(fmt.Errorf("init account-history handler: %w", err))
+	}
+	mux.HandleFunc("GET /api/v1/accounts/{address}/transactions", handlers.CustomHandler(accountHistoryHandler.GetAccountTransactions))
+	mux.HandleFunc("GET /api/v1/accounts/{address}/operations", handlers.CustomHandler(accountHistoryHandler.GetAccountOperations))
+	mux.HandleFunc("GET /api/v1/accounts/{address}/state-changes", handlers.CustomHandler(accountHistoryHandler.GetAccountStateChanges))
+
 	return mux
 }
 

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -56,7 +56,11 @@ func (s *ApiServer) Start() error {
 		return err
 	}
 
-	apiHandler := s.initMiddleware(s.initHandlers())
+	mux, err := s.initHandlers()
+	if err != nil {
+		return fmt.Errorf("initializing handlers: %w", err)
+	}
+	apiHandler := s.initMiddleware(mux)
 	metricsHandler := middleware.Chain(s.initMetricsHandler(), middleware.Recover())
 	return s.startServers(apiHandler, metricsHandler)
 }
@@ -84,7 +88,7 @@ func (s *ApiServer) initServices() error {
 	return nil
 }
 
-func (s *ApiServer) initHandlers() *http.ServeMux {
+func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
 	mux := http.NewServeMux()
 
 	// Initialize health check handler
@@ -116,13 +120,13 @@ func (s *ApiServer) initHandlers() *http.ServeMux {
 		s.cfg.AppConfig.AccountHistoryMaxLimit,
 	)
 	if err != nil {
-		panic(fmt.Errorf("init account-history handler: %w", err))
+		return nil, fmt.Errorf("init account-history handler: %w", err)
 	}
 	mux.HandleFunc("GET /api/v1/accounts/{address}/transactions", handlers.CustomHandler(accountHistoryHandler.GetAccountTransactions))
 	mux.HandleFunc("GET /api/v1/accounts/{address}/operations", handlers.CustomHandler(accountHistoryHandler.GetAccountOperations))
 	mux.HandleFunc("GET /api/v1/accounts/{address}/state-changes", handlers.CustomHandler(accountHistoryHandler.GetAccountStateChanges))
 
-	return mux
+	return mux, nil
 }
 
 func (s *ApiServer) initMetricsHandler() http.Handler {

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -54,7 +54,11 @@ func TestApiServer_initServices_RejectsNonPositiveBalanceConcurrency(t *testing.
 
 func TestApiServer_initHandlers(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	cfg := &config.Config{AppConfig: config.AppConfig{ProtocolsConfigPath: "testdata/protocols.json"}}
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+	}}
 	s := &ApiServer{cfg: cfg, registry: reg}
 	mux := s.initHandlers()
 	require.NotNil(t, mux)
@@ -67,7 +71,11 @@ func TestApiServer_initHandlers(t *testing.T) {
 
 func TestApiServer_initHandlers_DoesNotServeMetrics(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	cfg := &config.Config{AppConfig: config.AppConfig{ProtocolsConfigPath: "testdata/protocols.json"}}
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+	}}
 	s := &ApiServer{cfg: cfg, registry: reg}
 	mux := s.initHandlers()
 
@@ -113,6 +121,28 @@ func TestApiServer_initMiddleware(t *testing.T) {
 	mux := http.NewServeMux()
 	h := s.initMiddleware(mux)
 	require.NotNil(t, h)
+}
+
+func TestApiServer_initHandlers_RegistersAccountHistoryRoutes(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+	}}
+	s := &ApiServer{cfg: cfg, registry: reg}
+	mux := s.initHandlers()
+	require.NotNil(t, mux)
+
+	for _, path := range []string{
+		"/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/transactions",
+		"/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/operations",
+		"/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/state-changes",
+	} {
+		handler, pattern := mux.Handler(&http.Request{Method: "GET", URL: mustParseURL(path)})
+		assert.NotNil(t, handler, "no handler registered for %s", path)
+		assert.NotEmpty(t, pattern, "no pattern matched for %s", path)
+	}
 }
 
 func mustParseURL(path string) *url.URL {

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -60,7 +60,8 @@ func TestApiServer_initHandlers(t *testing.T) {
 		AccountHistoryMaxLimit:     100,
 	}}
 	s := &ApiServer{cfg: cfg, registry: reg}
-	mux := s.initHandlers()
+	mux, err := s.initHandlers()
+	require.NoError(t, err)
 	require.NotNil(t, mux)
 	handler, pattern := mux.Handler(&http.Request{Method: "GET", URL: mustParseURL("/api/v1/ping")})
 	assert.NotNil(t, handler)
@@ -77,7 +78,8 @@ func TestApiServer_initHandlers_DoesNotServeMetrics(t *testing.T) {
 		AccountHistoryMaxLimit:     100,
 	}}
 	s := &ApiServer{cfg: cfg, registry: reg}
-	mux := s.initHandlers()
+	mux, err := s.initHandlers()
+	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -131,7 +133,8 @@ func TestApiServer_initHandlers_RegistersAccountHistoryRoutes(t *testing.T) {
 		AccountHistoryMaxLimit:     100,
 	}}
 	s := &ApiServer{cfg: cfg, registry: reg}
-	mux := s.initHandlers()
+	mux, err := s.initHandlers()
+	require.NoError(t, err)
 	require.NotNil(t, mux)
 
 	for _, path := range []string{
@@ -143,6 +146,19 @@ func TestApiServer_initHandlers_RegistersAccountHistoryRoutes(t *testing.T) {
 		assert.NotNil(t, handler, "no handler registered for %s", path)
 		assert.NotEmpty(t, pattern, "no pattern matched for %s", path)
 	}
+}
+
+func TestApiServer_initHandlers_ReturnsErrorOnInvalidConfig(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	// Zero AccountHistoryDefaultLimit makes the constructor fail.
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath: "testdata/protocols.json",
+	}}
+	s := &ApiServer{cfg: cfg, registry: reg}
+	mux, err := s.initHandlers()
+	require.Error(t, err)
+	assert.Nil(t, mux)
+	assert.Contains(t, err.Error(), "init account-history handler")
 }
 
 func mustParseURL(path string) *url.URL {

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -137,15 +137,10 @@ func TestApiServer_initHandlers_RegistersAccountHistoryRoutes(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, mux)
 
-	for _, path := range []string{
-		"/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/transactions",
-		"/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/operations",
-		"/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/state-changes",
-	} {
-		handler, pattern := mux.Handler(&http.Request{Method: "GET", URL: mustParseURL(path)})
-		assert.NotNil(t, handler, "no handler registered for %s", path)
-		assert.NotEmpty(t, pattern, "no pattern matched for %s", path)
-	}
+	path := "/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/transactions"
+	handler, pattern := mux.Handler(&http.Request{Method: "GET", URL: mustParseURL(path)})
+	assert.NotNil(t, handler, "no handler registered for %s", path)
+	assert.NotEmpty(t, pattern, "no pattern matched for %s", path)
 }
 
 func TestApiServer_initHandlers_ReturnsErrorOnInvalidConfig(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,12 +32,12 @@ type AppConfig struct {
 	// so peak upstream load is concurrent_requests * WalletBackendBalanceConcurrency.
 	WalletBackendBalanceConcurrency int
 	// AccountHistoryDefaultLimit is the default page size for the
-	// /api/v1/accounts/{address}/transactions, /operations, and /state-changes
-	// endpoints when the client does not pass ?limit=. Must be > 0 and
-	// <= AccountHistoryMaxLimit.
+	// GET /api/v1/accounts/{address}/transactions endpoint when the client
+	// does not pass ?limit=. Must be > 0 and <= AccountHistoryMaxLimit.
 	AccountHistoryDefaultLimit int
-	// AccountHistoryMaxLimit is the maximum page size accepted by the same
-	// endpoints. Requests above this limit are rejected with 400. Must be > 0.
+	// AccountHistoryMaxLimit is the maximum page size accepted by that
+	// endpoint. Requests above it are rejected with 400. Must be > 0 and
+	// <= 100 (the wallet-backend upstream page-size cap).
 	AccountHistoryMaxLimit int
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,14 @@ type AppConfig struct {
 	// count for that fan-out. The limit is enforced per-request via errgroup.SetLimit,
 	// so peak upstream load is concurrent_requests * WalletBackendBalanceConcurrency.
 	WalletBackendBalanceConcurrency int
+	// AccountHistoryDefaultLimit is the default page size for the
+	// /api/v1/accounts/{address}/transactions, /operations, and /state-changes
+	// endpoints when the client does not pass ?limit=. Must be > 0 and
+	// <= AccountHistoryMaxLimit.
+	AccountHistoryDefaultLimit int
+	// AccountHistoryMaxLimit is the maximum page size accepted by the same
+	// endpoints. Requests above this limit are rejected with 400. Must be > 0.
+	AccountHistoryMaxLimit int
 }
 
 type RPCConfig struct {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -65,10 +65,6 @@ func NewHTTP(reg prometheus.Registerer) *HTTP {
 		RequestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name: "freighter_http_request_duration_seconds",
 			Help: "Duration of HTTP requests in seconds.",
-			// 0.075/0.15/0.35/0.75 subdivide the 50ms-1s range where the
-			// account-history endpoint's distribution lives; without them,
-			// histogram_quantile interpolates p95/p99 across buckets up to
-			// 500ms wide and the reported tail swings by hundreds of ms.
 			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1, 2.5, 5, 10, 30},
 		}, []string{"handler", "method", "code"}),
 		InFlightRequests: prometheus.NewGauge(prometheus.GaugeOpts{
@@ -102,9 +98,6 @@ func NewService(reg prometheus.Registerer) *Service {
 		CallDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name: "freighter_service_call_duration_seconds",
 			Help: "Duration of external service calls in seconds.",
-			// Mirrors the HTTP histogram's 0.075-0.75 additions so the
-			// wallet-backend leg can be compared against end-to-end handler
-			// latency at the same resolution (tail attribution).
 			Buckets: []float64{0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1, 2.5, 5, 10, 30},
 		}, []string{"service", "method", "network"}),
 		ErrorsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -63,8 +63,8 @@ func NewHTTP(reg prometheus.Registerer) *HTTP {
 			Help: "Total number of HTTP requests.",
 		}, []string{"handler", "method", "code"}),
 		RequestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: "freighter_http_request_duration_seconds",
-			Help: "Duration of HTTP requests in seconds.",
+			Name:    "freighter_http_request_duration_seconds",
+			Help:    "Duration of HTTP requests in seconds.",
 			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1, 2.5, 5, 10, 30},
 		}, []string{"handler", "method", "code"}),
 		InFlightRequests: prometheus.NewGauge(prometheus.GaugeOpts{
@@ -96,8 +96,8 @@ func NewService(reg prometheus.Registerer) *Service {
 			Help: "Total number of external service calls.",
 		}, []string{"service", "method", "network"}),
 		CallDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name: "freighter_service_call_duration_seconds",
-			Help: "Duration of external service calls in seconds.",
+			Name:    "freighter_service_call_duration_seconds",
+			Help:    "Duration of external service calls in seconds.",
 			Buckets: []float64{0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1, 2.5, 5, 10, 30},
 		}, []string{"service", "method", "network"}),
 		ErrorsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -63,9 +63,13 @@ func NewHTTP(reg prometheus.Registerer) *HTTP {
 			Help: "Total number of HTTP requests.",
 		}, []string{"handler", "method", "code"}),
 		RequestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "freighter_http_request_duration_seconds",
-			Help:    "Duration of HTTP requests in seconds.",
-			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+			Name: "freighter_http_request_duration_seconds",
+			Help: "Duration of HTTP requests in seconds.",
+			// 0.075/0.15/0.35/0.75 subdivide the 50ms-1s range where the
+			// account-history endpoint's distribution lives; without them,
+			// histogram_quantile interpolates p95/p99 across buckets up to
+			// 500ms wide and the reported tail swings by hundreds of ms.
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1, 2.5, 5, 10, 30},
 		}, []string{"handler", "method", "code"}),
 		InFlightRequests: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "freighter_http_in_flight_requests",
@@ -96,9 +100,12 @@ func NewService(reg prometheus.Registerer) *Service {
 			Help: "Total number of external service calls.",
 		}, []string{"service", "method", "network"}),
 		CallDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "freighter_service_call_duration_seconds",
-			Help:    "Duration of external service calls in seconds.",
-			Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+			Name: "freighter_service_call_duration_seconds",
+			Help: "Duration of external service calls in seconds.",
+			// Mirrors the HTTP histogram's 0.075-0.75 additions so the
+			// wallet-backend leg can be compared against end-to-end handler
+			// latency at the same resolution (tail attribution).
+			Buckets: []float64{0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.25, 0.35, 0.5, 0.75, 1, 2.5, 5, 10, 30},
 		}, []string{"service", "method", "network"}),
 		ErrorsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "freighter_service_errors_total",

--- a/internal/services/account_history_mapping.go
+++ b/internal/services/account_history_mapping.go
@@ -1,0 +1,97 @@
+// ABOUTME: Maps wallet-backend SDK transaction/operation/state-change types into freighter snake_case REST types.
+// ABOUTME: mapStateChange is the only non-trivial mapper — a type switch over the 9 SDK state-change variants.
+package services
+
+import (
+	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
+
+	"github.com/stellar/freighter-backend-v2/internal/types"
+)
+
+// mapTransaction copies an SDK transaction into the snake_case REST shape.
+func mapTransaction(t *wbtypes.GraphQLTransaction) types.Transaction {
+	return types.Transaction{
+		Hash:            t.Hash,
+		FeeCharged:      t.FeeCharged,
+		ResultCode:      t.ResultCode,
+		LedgerNumber:    t.LedgerNumber,
+		LedgerCreatedAt: t.LedgerCreatedAt,
+		IsFeeBump:       t.IsFeeBump,
+		IngestedAt:      t.IngestedAt,
+	}
+}
+
+// mapOperation copies an SDK operation into the snake_case REST shape.
+func mapOperation(o *wbtypes.Operation) types.Operation {
+	return types.Operation{
+		ID:              o.ID,
+		OperationType:   string(o.OperationType),
+		OperationXDR:    o.OperationXdr,
+		ResultCode:      o.ResultCode,
+		Successful:      o.Successful,
+		LedgerNumber:    o.LedgerNumber,
+		LedgerCreatedAt: o.LedgerCreatedAt,
+		IngestedAt:      o.IngestedAt,
+	}
+}
+
+// mapStateChange dispatches an SDK state-change node to the matching freighter
+// variant. The SDK's UnmarshalStateChangeNode rejects unknown __typename, so
+// the default branch is unreachable in practice; it degrades a hypothetical
+// future variant to type+reason rather than panicking or dropping the row.
+func mapStateChange(n wbtypes.StateChangeNode) types.StateChange {
+	base := types.StateChangeBase{
+		Type:            string(n.GetType()),
+		Reason:          string(n.GetReason()),
+		LedgerNumber:    n.GetLedgerNumber(),
+		LedgerCreatedAt: n.GetLedgerCreatedAt(),
+		IngestedAt:      n.GetIngestedAt(),
+	}
+	switch sc := n.(type) {
+	case *wbtypes.StandardBalanceChange:
+		return &types.StandardBalanceChange{StateChangeBase: base, StandardBalanceTokenID: sc.TokenID, Amount: sc.Amount}
+	case *wbtypes.AccountChange:
+		return &types.AccountChange{StateChangeBase: base, FunderAddress: sc.FunderAddress}
+	case *wbtypes.SignerChange:
+		return &types.SignerChange{StateChangeBase: base, SignerAddress: sc.SignerAddress, SignerWeights: sc.SignerWeights}
+	case *wbtypes.SignerThresholdsChange:
+		return &types.SignerThresholdsChange{StateChangeBase: base, Thresholds: sc.Thresholds}
+	case *wbtypes.MetadataChange:
+		return &types.MetadataChange{StateChangeBase: base, MetadataKeyValue: sc.KeyValue}
+	case *wbtypes.FlagsChange:
+		return &types.FlagsChange{StateChangeBase: base, Flags: sc.Flags}
+	case *wbtypes.TrustlineChange:
+		return &types.TrustlineChange{StateChangeBase: base, TrustlineTokenID: sc.TokenID, Limit: sc.Limit, TrustlineLiquidityPoolID: sc.LiquidityPoolID}
+	case *wbtypes.ReservesChange:
+		return &types.ReservesChange{StateChangeBase: base, SponsoredAddress: sc.SponsoredAddress, SponsorAddress: sc.SponsorAddress, SponsoredData: sc.SponsoredData, SponsoredTrustline: sc.SponsoredTrustline, ClaimableBalanceID: sc.ClaimableBalanceID, LiquidityPoolID: sc.LiquidityPoolID}
+	case *wbtypes.BalanceAuthorizationChange:
+		return &types.BalanceAuthorizationChange{StateChangeBase: base, BalanceAuthTokenID: sc.TokenID, BalanceAuthLiquidityPoolID: sc.LiquidityPoolID, Flags: sc.Flags}
+	default:
+		return &base
+	}
+}
+
+// mapAccountTransactionEdge flattens one SDK edge into an AccountTransaction.
+// Nil operation/state-change entries are skipped; the result slices are always
+// non-nil so the JSON encoder emits [] rather than null.
+func mapAccountTransactionEdge(e *wbtypes.AccountTransactionEdge) *types.AccountTransaction {
+	ops := make([]types.Operation, 0, len(e.Operations))
+	for _, o := range e.Operations {
+		if o == nil {
+			continue
+		}
+		ops = append(ops, mapOperation(o))
+	}
+	scs := make([]types.StateChange, 0, len(e.StateChanges))
+	for _, sc := range e.StateChanges {
+		if sc == nil {
+			continue
+		}
+		scs = append(scs, mapStateChange(sc))
+	}
+	return &types.AccountTransaction{
+		Transaction:  mapTransaction(e.Node),
+		Operations:   ops,
+		StateChanges: scs,
+	}
+}

--- a/internal/services/account_history_mapping_test.go
+++ b/internal/services/account_history_mapping_test.go
@@ -39,24 +39,42 @@ func TestMapStateChange_AllVariants(t *testing.T) {
 		in   wbtypes.StateChangeNode
 		want types.StateChange
 	}{
-		{"standard_balance", &wbtypes.StandardBalanceChange{BaseStateChangeFields: base, TokenID: "native", Amount: "10"},
-			&types.StandardBalanceChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, StandardBalanceTokenID: "native", Amount: "10"}},
-		{"account", &wbtypes.AccountChange{BaseStateChangeFields: base, FunderAddress: &s},
-			&types.AccountChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, FunderAddress: &s}},
-		{"signer", &wbtypes.SignerChange{BaseStateChangeFields: base, SignerAddress: &s, SignerWeights: &s},
-			&types.SignerChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, SignerAddress: &s, SignerWeights: &s}},
-		{"signer_thresholds", &wbtypes.SignerThresholdsChange{BaseStateChangeFields: base, Thresholds: "1,2,3"},
-			&types.SignerThresholdsChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, Thresholds: "1,2,3"}},
-		{"metadata", &wbtypes.MetadataChange{BaseStateChangeFields: base, KeyValue: "k=v"},
-			&types.MetadataChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, MetadataKeyValue: "k=v"}},
-		{"flags", &wbtypes.FlagsChange{BaseStateChangeFields: base, Flags: []string{"AUTH"}},
-			&types.FlagsChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, Flags: []string{"AUTH"}}},
-		{"trustline", &wbtypes.TrustlineChange{BaseStateChangeFields: base, TokenID: &s, Limit: &s, LiquidityPoolID: &s},
-			&types.TrustlineChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, TrustlineTokenID: &s, Limit: &s, TrustlineLiquidityPoolID: &s}},
-		{"reserves", &wbtypes.ReservesChange{BaseStateChangeFields: base, SponsoredAddress: &s, SponsorAddress: &s, SponsoredData: &s, SponsoredTrustline: &s, ClaimableBalanceID: &s, LiquidityPoolID: &s},
-			&types.ReservesChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, SponsoredAddress: &s, SponsorAddress: &s, SponsoredData: &s, SponsoredTrustline: &s, ClaimableBalanceID: &s, LiquidityPoolID: &s}},
-		{"balance_authorization", &wbtypes.BalanceAuthorizationChange{BaseStateChangeFields: base, TokenID: &s, LiquidityPoolID: &s, Flags: []string{"X"}},
-			&types.BalanceAuthorizationChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, BalanceAuthTokenID: &s, BalanceAuthLiquidityPoolID: &s, Flags: []string{"X"}}},
+		{
+			"standard_balance", &wbtypes.StandardBalanceChange{BaseStateChangeFields: base, TokenID: "native", Amount: "10"},
+			&types.StandardBalanceChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, StandardBalanceTokenID: "native", Amount: "10"},
+		},
+		{
+			"account", &wbtypes.AccountChange{BaseStateChangeFields: base, FunderAddress: &s},
+			&types.AccountChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, FunderAddress: &s},
+		},
+		{
+			"signer", &wbtypes.SignerChange{BaseStateChangeFields: base, SignerAddress: &s, SignerWeights: &s},
+			&types.SignerChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, SignerAddress: &s, SignerWeights: &s},
+		},
+		{
+			"signer_thresholds", &wbtypes.SignerThresholdsChange{BaseStateChangeFields: base, Thresholds: "1,2,3"},
+			&types.SignerThresholdsChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, Thresholds: "1,2,3"},
+		},
+		{
+			"metadata", &wbtypes.MetadataChange{BaseStateChangeFields: base, KeyValue: "k=v"},
+			&types.MetadataChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, MetadataKeyValue: "k=v"},
+		},
+		{
+			"flags", &wbtypes.FlagsChange{BaseStateChangeFields: base, Flags: []string{"AUTH"}},
+			&types.FlagsChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, Flags: []string{"AUTH"}},
+		},
+		{
+			"trustline", &wbtypes.TrustlineChange{BaseStateChangeFields: base, TokenID: &s, Limit: &s, LiquidityPoolID: &s},
+			&types.TrustlineChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, TrustlineTokenID: &s, Limit: &s, TrustlineLiquidityPoolID: &s},
+		},
+		{
+			"reserves", &wbtypes.ReservesChange{BaseStateChangeFields: base, SponsoredAddress: &s, SponsorAddress: &s, SponsoredData: &s, SponsoredTrustline: &s, ClaimableBalanceID: &s, LiquidityPoolID: &s},
+			&types.ReservesChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, SponsoredAddress: &s, SponsorAddress: &s, SponsoredData: &s, SponsoredTrustline: &s, ClaimableBalanceID: &s, LiquidityPoolID: &s},
+		},
+		{
+			"balance_authorization", &wbtypes.BalanceAuthorizationChange{BaseStateChangeFields: base, TokenID: &s, LiquidityPoolID: &s, Flags: []string{"X"}},
+			&types.BalanceAuthorizationChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, BalanceAuthTokenID: &s, BalanceAuthLiquidityPoolID: &s, Flags: []string{"X"}},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/services/account_history_mapping_test.go
+++ b/internal/services/account_history_mapping_test.go
@@ -1,0 +1,88 @@
+// ABOUTME: Unit tests for the wbclient -> freighter snake_case mapping helpers.
+// ABOUTME: Covers transaction/operation field mapping, all 9 state-change variants, and edge flattening.
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
+
+	"github.com/stellar/freighter-backend-v2/internal/types"
+)
+
+func TestMapTransactionAndOperation(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	tx := mapTransaction(&wbtypes.GraphQLTransaction{
+		Hash: "h1", FeeCharged: 100, ResultCode: "txSUCCESS",
+		LedgerNumber: 42, LedgerCreatedAt: ts, IsFeeBump: true, IngestedAt: ts,
+	})
+	assert.Equal(t, types.Transaction{Hash: "h1", FeeCharged: 100, ResultCode: "txSUCCESS", LedgerNumber: 42, LedgerCreatedAt: ts, IsFeeBump: true, IngestedAt: ts}, tx)
+
+	op := mapOperation(&wbtypes.Operation{
+		ID: 7, OperationType: wbtypes.OperationTypePayment, OperationXdr: "AAA",
+		ResultCode: "opSUCCESS", Successful: true, LedgerNumber: 42, LedgerCreatedAt: ts, IngestedAt: ts,
+	})
+	assert.Equal(t, types.Operation{ID: 7, OperationType: "PAYMENT", OperationXDR: "AAA", ResultCode: "opSUCCESS", Successful: true, LedgerNumber: 42, LedgerCreatedAt: ts, IngestedAt: ts}, op)
+}
+
+func TestMapStateChange_AllVariants(t *testing.T) {
+	t.Parallel()
+	base := wbtypes.BaseStateChangeFields{Type: wbtypes.StateChangeCategoryBalance, Reason: wbtypes.StateChangeReasonDebit}
+	s := "x"
+	cases := []struct {
+		name string
+		in   wbtypes.StateChangeNode
+		want types.StateChange
+	}{
+		{"standard_balance", &wbtypes.StandardBalanceChange{BaseStateChangeFields: base, TokenID: "native", Amount: "10"},
+			&types.StandardBalanceChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, StandardBalanceTokenID: "native", Amount: "10"}},
+		{"account", &wbtypes.AccountChange{BaseStateChangeFields: base, FunderAddress: &s},
+			&types.AccountChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, FunderAddress: &s}},
+		{"signer", &wbtypes.SignerChange{BaseStateChangeFields: base, SignerAddress: &s, SignerWeights: &s},
+			&types.SignerChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, SignerAddress: &s, SignerWeights: &s}},
+		{"signer_thresholds", &wbtypes.SignerThresholdsChange{BaseStateChangeFields: base, Thresholds: "1,2,3"},
+			&types.SignerThresholdsChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, Thresholds: "1,2,3"}},
+		{"metadata", &wbtypes.MetadataChange{BaseStateChangeFields: base, KeyValue: "k=v"},
+			&types.MetadataChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, MetadataKeyValue: "k=v"}},
+		{"flags", &wbtypes.FlagsChange{BaseStateChangeFields: base, Flags: []string{"AUTH"}},
+			&types.FlagsChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, Flags: []string{"AUTH"}}},
+		{"trustline", &wbtypes.TrustlineChange{BaseStateChangeFields: base, TokenID: &s, Limit: &s, LiquidityPoolID: &s},
+			&types.TrustlineChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, TrustlineTokenID: &s, Limit: &s, TrustlineLiquidityPoolID: &s}},
+		{"reserves", &wbtypes.ReservesChange{BaseStateChangeFields: base, SponsoredAddress: &s, SponsorAddress: &s, SponsoredData: &s, SponsoredTrustline: &s, ClaimableBalanceID: &s, LiquidityPoolID: &s},
+			&types.ReservesChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, SponsoredAddress: &s, SponsorAddress: &s, SponsoredData: &s, SponsoredTrustline: &s, ClaimableBalanceID: &s, LiquidityPoolID: &s}},
+		{"balance_authorization", &wbtypes.BalanceAuthorizationChange{BaseStateChangeFields: base, TokenID: &s, LiquidityPoolID: &s, Flags: []string{"X"}},
+			&types.BalanceAuthorizationChange{StateChangeBase: types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT"}, BalanceAuthTokenID: &s, BalanceAuthLiquidityPoolID: &s, Flags: []string{"X"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, mapStateChange(tc.in))
+		})
+	}
+}
+
+func TestMapAccountTransactionEdge_FlattensAndGuaranteesNonNilSlices(t *testing.T) {
+	t.Parallel()
+	edge := &wbtypes.AccountTransactionEdge{
+		Node:         &wbtypes.GraphQLTransaction{Hash: "h1"},
+		Cursor:       "c1",
+		Operations:   []*wbtypes.Operation{{ID: 1, OperationType: wbtypes.OperationTypePayment}, nil},
+		StateChanges: []wbtypes.StateChangeNode{&wbtypes.StandardBalanceChange{BaseStateChangeFields: wbtypes.BaseStateChangeFields{Type: wbtypes.StateChangeCategoryBalance}, Amount: "5"}, nil},
+	}
+	got := mapAccountTransactionEdge(edge)
+	assert.Equal(t, "h1", got.Hash)
+	require.Len(t, got.Operations, 1, "nil operation entry skipped")
+	assert.Equal(t, int64(1), got.Operations[0].ID)
+	require.Len(t, got.StateChanges, 1, "nil state-change entry skipped")
+
+	empty := mapAccountTransactionEdge(&wbtypes.AccountTransactionEdge{Node: &wbtypes.GraphQLTransaction{Hash: "h2"}})
+	assert.NotNil(t, empty.Operations)
+	assert.NotNil(t, empty.StateChanges)
+	assert.Empty(t, empty.Operations)
+	assert.Empty(t, empty.StateChanges)
+}

--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -232,9 +232,99 @@ func (w *walletBackendService) GetBalancesByAccountAddresses(ctx context.Context
 	return results, nil
 }
 
-// GetAccountTransactions is a temporary stub replaced by the real implementation in Task 6 (TDD).
-func (w *walletBackendService) GetAccountTransactions(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.GraphQLTransaction], error) {
-	return nil, fmt.Errorf("not implemented")
+// translateParams converts AccountHistoryParams into the (first, last, after,
+// before) tuple the wbclient SDK methods take. PaginationDirectionPrev maps
+// to (last, before); anything else (including the default "next") maps to
+// (first, after). Cursor is opaque and forwarded verbatim.
+func translateParams(p types.AccountHistoryParams) (first, last *int32, after, before *string) {
+	limit := p.Limit
+	if p.Direction == types.PaginationDirectionPrev {
+		return nil, &limit, nil, p.Cursor
+	}
+	return &limit, nil, p.Cursor, nil
+}
+
+// toPaginationInfo copies an upstream PageInfo into the freighter-backend
+// response envelope shape. Cursors that the SDK omits (HasNextPage=false /
+// HasPreviousPage=false) are returned as nil pointers per the spec.
+func toPaginationInfo(pi *wbtypes.PageInfo) types.PaginationInfo {
+	out := types.PaginationInfo{
+		HasNext:     pi.HasNextPage,
+		HasPrevious: pi.HasPreviousPage,
+	}
+	if pi.HasNextPage {
+		out.NextCursor = pi.EndCursor
+	}
+	if pi.HasPreviousPage {
+		out.PrevCursor = pi.StartCursor
+	}
+	return out
+}
+
+// recordWBCall records call metrics with one carve-out: ErrAccountNotFound
+// is a normal client outcome (the account doesn't exist in wallet-backend's
+// view), not a service failure, so the ErrorsTotal counter is not incremented
+// for it. CallsTotal and CallDuration always record.
+func (w *walletBackendService) recordWBCall(method, network string, start time.Time, err error) {
+	if w.svcMetrics == nil {
+		return
+	}
+	dur := time.Since(start).Seconds()
+	w.svcMetrics.CallsTotal.WithLabelValues(walletBackendServiceName, method, network).Inc()
+	w.svcMetrics.CallDuration.WithLabelValues(walletBackendServiceName, method, network).Observe(dur)
+	if err != nil && !errors.Is(err, wbclient.ErrAccountNotFound) {
+		w.svcMetrics.ErrorsTotal.WithLabelValues(walletBackendServiceName, method, network, metrics.ClassifyError(err)).Inc()
+	}
+}
+
+// emptyTxPage is the empty-page response shape used when wallet-backend
+// returns a null transactions connection on an existing account (schema-
+// valid per wallet-backend PR #616 — distinct from ErrAccountNotFound).
+func emptyTxPage() *types.PaginatedResponse[*wbtypes.GraphQLTransaction] {
+	return &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{
+		Data:       []*wbtypes.GraphQLTransaction{},
+		Pagination: types.PaginationInfo{},
+	}
+}
+
+// GetAccountTransactions returns a paginated list of transactions for the given
+// account address and network. It translates the freighter-backend pagination
+// params into the (first/last/after/before) tuple expected by the wbclient SDK
+// and maps the upstream TransactionConnection into the shared PaginatedResponse
+// envelope. ErrAccountNotFound is returned unwrapped so callers can distinguish
+// a missing account from systemic upstream failures.
+func (w *walletBackendService) GetAccountTransactions(ctx context.Context, address, network string, p types.AccountHistoryParams) (_ *types.PaginatedResponse[*wbtypes.GraphQLTransaction], err error) {
+	start := time.Now()
+	defer func() { w.recordWBCall("GetAccountTransactions", network, start, err) }()
+
+	client := w.configureNetworkClient(network)
+	if client == nil {
+		return nil, fmt.Errorf("wallet backend client not configured for network: %s", network)
+	}
+
+	first, last, after, before := translateParams(p)
+	conn, err := client.GetAccountTransactions(ctx, address, p.Since, p.Until, first, last, after, before)
+	if err != nil {
+		if errors.Is(err, wbclient.ErrAccountNotFound) {
+			return nil, err
+		}
+		return nil, classifyWBError(err)
+	}
+	if conn == nil {
+		return emptyTxPage(), nil
+	}
+
+	nodes := make([]*wbtypes.GraphQLTransaction, 0, len(conn.Edges))
+	for _, e := range conn.Edges {
+		if e.Node == nil {
+			continue
+		}
+		nodes = append(nodes, e.Node)
+	}
+	return &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{
+		Data:       nodes,
+		Pagination: toPaginationInfo(conn.PageInfo),
+	}, nil
 }
 
 // GetAccountOperations is a temporary stub replaced by the real implementation in Task 7 (TDD).

--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -232,6 +232,21 @@ func (w *walletBackendService) GetBalancesByAccountAddresses(ctx context.Context
 	return results, nil
 }
 
+// GetAccountTransactions is a temporary stub replaced by the real implementation in Task 6 (TDD).
+func (w *walletBackendService) GetAccountTransactions(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.GraphQLTransaction], error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// GetAccountOperations is a temporary stub replaced by the real implementation in Task 7 (TDD).
+func (w *walletBackendService) GetAccountOperations(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.Operation], error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// GetAccountStateChanges is a temporary stub replaced by the real implementation in Task 8 (TDD).
+func (w *walletBackendService) GetAccountStateChanges(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[wbtypes.StateChangeNode], error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // classifyWBError wraps a systemic wbclient error with an UpstreamError so
 // metrics.ClassifyError can emit a faithful sub-label
 // (graphql_error / http_error[:code]). The typed account-not-found case is

--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -1,5 +1,5 @@
 // ABOUTME: Wallet-backend service implementation that wraps the wbclient SDK and exposes the methods used by API handlers.
-// ABOUTME: Hosts the balances fan-out and the per-account history methods (transactions / operations / state-changes), sharing translate/page-info helpers.
+// ABOUTME: Hosts the balances fan-out and the single account-transactions history method (with embedded ops + state changes), sharing translate/page-info helpers.
 package services
 
 import (
@@ -285,40 +285,18 @@ func (w *walletBackendService) recordWBCall(method, network string, start time.T
 // emptyTxPage is the empty-page response shape used when wallet-backend
 // returns a null transactions connection on an existing account (schema-
 // valid per wallet-backend PR #616 — distinct from ErrAccountNotFound).
-func emptyTxPage() *types.PaginatedResponse[*wbtypes.GraphQLTransaction] {
-	return &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{
-		Data:       []*wbtypes.GraphQLTransaction{},
+func emptyTxPage() *types.PaginatedResponse[*types.AccountTransaction] {
+	return &types.PaginatedResponse[*types.AccountTransaction]{
+		Data:       []*types.AccountTransaction{},
 		Pagination: types.PaginationInfo{},
 	}
 }
 
-// emptyOpPage is the empty-page response shape used when wallet-backend
-// returns a null operations connection on an existing account (schema-
-// valid per wallet-backend PR #616 — distinct from ErrAccountNotFound).
-func emptyOpPage() *types.PaginatedResponse[*wbtypes.Operation] {
-	return &types.PaginatedResponse[*wbtypes.Operation]{
-		Data:       []*wbtypes.Operation{},
-		Pagination: types.PaginationInfo{},
-	}
-}
-
-// emptyStateChangePage is the empty-page response shape used when wallet-backend
-// returns a null stateChanges connection on an existing account (schema-valid
-// per wallet-backend PR #616 — distinct from ErrAccountNotFound).
-func emptyStateChangePage() *types.PaginatedResponse[wbtypes.StateChangeNode] {
-	return &types.PaginatedResponse[wbtypes.StateChangeNode]{
-		Data:       []wbtypes.StateChangeNode{},
-		Pagination: types.PaginationInfo{},
-	}
-}
-
-// GetAccountTransactions returns a paginated list of transactions for the given
-// account address and network. It translates the freighter-backend pagination
-// params into the (first/last/after/before) tuple expected by the wbclient SDK
-// and maps the upstream TransactionConnection into the shared PaginatedResponse
-// envelope. ErrAccountNotFound is returned unwrapped so callers can distinguish
-// a missing account from systemic upstream failures.
-func (w *walletBackendService) GetAccountTransactions(ctx context.Context, address, network string, p types.AccountHistoryParams) (_ *types.PaginatedResponse[*wbtypes.GraphQLTransaction], err error) {
+// GetAccountTransactions returns one page of an account's transactions, each
+// embedding that account's operations and state changes, via the wallet-backend
+// single nested GraphQL call. ErrAccountNotFound is returned unwrapped so callers
+// can distinguish a missing account from systemic upstream failures.
+func (w *walletBackendService) GetAccountTransactions(ctx context.Context, address, network string, p types.AccountHistoryParams) (_ *types.PaginatedResponse[*types.AccountTransaction], err error) {
 	start := time.Now()
 	defer func() { w.recordWBCall("GetAccountTransactions", network, start, err) }()
 
@@ -328,7 +306,7 @@ func (w *walletBackendService) GetAccountTransactions(ctx context.Context, addre
 	}
 
 	first, last, after, before := translateParams(p)
-	conn, err := client.GetAccountTransactions(ctx, address, p.Since, p.Until, first, last, after, before)
+	conn, err := client.GetAccountTransactionsWithOpsAndStateChanges(ctx, address, p.Since, p.Until, first, last, after, before)
 	if err != nil {
 		if errors.Is(err, wbclient.ErrAccountNotFound) {
 			return nil, err
@@ -339,91 +317,15 @@ func (w *walletBackendService) GetAccountTransactions(ctx context.Context, addre
 		return emptyTxPage(), nil
 	}
 
-	nodes := make([]*wbtypes.GraphQLTransaction, 0, len(conn.Edges))
+	items := make([]*types.AccountTransaction, 0, len(conn.Edges))
 	for _, e := range conn.Edges {
-		if e.Node == nil {
+		if e == nil || e.Node == nil {
 			continue
 		}
-		nodes = append(nodes, e.Node)
+		items = append(items, mapAccountTransactionEdge(e))
 	}
-	return &types.PaginatedResponse[*wbtypes.GraphQLTransaction]{
-		Data:       nodes,
-		Pagination: toPaginationInfo(conn.PageInfo),
-	}, nil
-}
-
-// GetAccountOperations returns one page of an account's operations from
-// wallet-backend. See GetAccountTransactions for the shared semantics around
-// ErrAccountNotFound, null-connection-as-empty-page, and nil-node skipping.
-func (w *walletBackendService) GetAccountOperations(ctx context.Context, address, network string, p types.AccountHistoryParams) (_ *types.PaginatedResponse[*wbtypes.Operation], err error) {
-	start := time.Now()
-	defer func() { w.recordWBCall("GetAccountOperations", network, start, err) }()
-
-	client := w.configureNetworkClient(network)
-	if client == nil {
-		return nil, fmt.Errorf("wallet backend client not configured for network: %s", network)
-	}
-
-	first, last, after, before := translateParams(p)
-	conn, err := client.GetAccountOperations(ctx, address, p.Since, p.Until, first, last, after, before)
-	if err != nil {
-		if errors.Is(err, wbclient.ErrAccountNotFound) {
-			return nil, err
-		}
-		return nil, classifyWBError(err)
-	}
-	if conn == nil {
-		return emptyOpPage(), nil
-	}
-
-	nodes := make([]*wbtypes.Operation, 0, len(conn.Edges))
-	for _, e := range conn.Edges {
-		if e.Node == nil {
-			continue
-		}
-		nodes = append(nodes, e.Node)
-	}
-	return &types.PaginatedResponse[*wbtypes.Operation]{
-		Data:       nodes,
-		Pagination: toPaginationInfo(conn.PageInfo),
-	}, nil
-}
-
-// GetAccountStateChanges returns one page of an account's state changes from
-// wallet-backend. See GetAccountTransactions for the shared semantics around
-// ErrAccountNotFound, null-connection-as-empty-page, and nil-node skipping.
-// The SDK's state-change-specific filter args (transactionHash, operationID,
-// category, reason) are passed as nil — v1 does not expose them.
-func (w *walletBackendService) GetAccountStateChanges(ctx context.Context, address, network string, p types.AccountHistoryParams) (_ *types.PaginatedResponse[wbtypes.StateChangeNode], err error) {
-	start := time.Now()
-	defer func() { w.recordWBCall("GetAccountStateChanges", network, start, err) }()
-
-	client := w.configureNetworkClient(network)
-	if client == nil {
-		return nil, fmt.Errorf("wallet backend client not configured for network: %s", network)
-	}
-
-	first, last, after, before := translateParams(p)
-	conn, err := client.GetAccountStateChanges(ctx, address, nil, nil, nil, nil, p.Since, p.Until, first, last, after, before)
-	if err != nil {
-		if errors.Is(err, wbclient.ErrAccountNotFound) {
-			return nil, err
-		}
-		return nil, classifyWBError(err)
-	}
-	if conn == nil {
-		return emptyStateChangePage(), nil
-	}
-
-	nodes := make([]wbtypes.StateChangeNode, 0, len(conn.Edges))
-	for _, e := range conn.Edges {
-		if e.Node == nil {
-			continue
-		}
-		nodes = append(nodes, e.Node)
-	}
-	return &types.PaginatedResponse[wbtypes.StateChangeNode]{
-		Data:       nodes,
+	return &types.PaginatedResponse[*types.AccountTransaction]{
+		Data:       items,
 		Pagination: toPaginationInfo(conn.PageInfo),
 	}, nil
 }

--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -287,6 +287,16 @@ func emptyTxPage() *types.PaginatedResponse[*wbtypes.GraphQLTransaction] {
 	}
 }
 
+// emptyOpPage is the empty-page response shape used when wallet-backend
+// returns a null operations connection on an existing account (schema-
+// valid per wallet-backend PR #616 — distinct from ErrAccountNotFound).
+func emptyOpPage() *types.PaginatedResponse[*wbtypes.Operation] {
+	return &types.PaginatedResponse[*wbtypes.Operation]{
+		Data:       []*wbtypes.Operation{},
+		Pagination: types.PaginationInfo{},
+	}
+}
+
 // GetAccountTransactions returns a paginated list of transactions for the given
 // account address and network. It translates the freighter-backend pagination
 // params into the (first/last/after/before) tuple expected by the wbclient SDK
@@ -327,9 +337,41 @@ func (w *walletBackendService) GetAccountTransactions(ctx context.Context, addre
 	}, nil
 }
 
-// GetAccountOperations is a temporary stub replaced by the real implementation in Task 7 (TDD).
-func (w *walletBackendService) GetAccountOperations(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.Operation], error) {
-	return nil, fmt.Errorf("not implemented")
+// GetAccountOperations returns one page of an account's operations from
+// wallet-backend. See GetAccountTransactions for the shared semantics around
+// ErrAccountNotFound, null-connection-as-empty-page, and nil-node skipping.
+func (w *walletBackendService) GetAccountOperations(ctx context.Context, address, network string, p types.AccountHistoryParams) (_ *types.PaginatedResponse[*wbtypes.Operation], err error) {
+	start := time.Now()
+	defer func() { w.recordWBCall("GetAccountOperations", network, start, err) }()
+
+	client := w.configureNetworkClient(network)
+	if client == nil {
+		return nil, fmt.Errorf("wallet backend client not configured for network: %s", network)
+	}
+
+	first, last, after, before := translateParams(p)
+	conn, err := client.GetAccountOperations(ctx, address, p.Since, p.Until, first, last, after, before)
+	if err != nil {
+		if errors.Is(err, wbclient.ErrAccountNotFound) {
+			return nil, err
+		}
+		return nil, classifyWBError(err)
+	}
+	if conn == nil {
+		return emptyOpPage(), nil
+	}
+
+	nodes := make([]*wbtypes.Operation, 0, len(conn.Edges))
+	for _, e := range conn.Edges {
+		if e.Node == nil {
+			continue
+		}
+		nodes = append(nodes, e.Node)
+	}
+	return &types.PaginatedResponse[*wbtypes.Operation]{
+		Data:       nodes,
+		Pagination: toPaginationInfo(conn.PageInfo),
+	}, nil
 }
 
 // GetAccountStateChanges is a temporary stub replaced by the real implementation in Task 8 (TDD).

--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -297,6 +297,16 @@ func emptyOpPage() *types.PaginatedResponse[*wbtypes.Operation] {
 	}
 }
 
+// emptyStateChangePage is the empty-page response shape used when wallet-backend
+// returns a null stateChanges connection on an existing account (schema-valid
+// per wallet-backend PR #616 — distinct from ErrAccountNotFound).
+func emptyStateChangePage() *types.PaginatedResponse[wbtypes.StateChangeNode] {
+	return &types.PaginatedResponse[wbtypes.StateChangeNode]{
+		Data:       []wbtypes.StateChangeNode{},
+		Pagination: types.PaginationInfo{},
+	}
+}
+
 // GetAccountTransactions returns a paginated list of transactions for the given
 // account address and network. It translates the freighter-backend pagination
 // params into the (first/last/after/before) tuple expected by the wbclient SDK
@@ -374,9 +384,43 @@ func (w *walletBackendService) GetAccountOperations(ctx context.Context, address
 	}, nil
 }
 
-// GetAccountStateChanges is a temporary stub replaced by the real implementation in Task 8 (TDD).
-func (w *walletBackendService) GetAccountStateChanges(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[wbtypes.StateChangeNode], error) {
-	return nil, fmt.Errorf("not implemented")
+// GetAccountStateChanges returns one page of an account's state changes from
+// wallet-backend. See GetAccountTransactions for the shared semantics around
+// ErrAccountNotFound, null-connection-as-empty-page, and nil-node skipping.
+// The SDK's state-change-specific filter args (transactionHash, operationID,
+// category, reason) are passed as nil — v1 does not expose them.
+func (w *walletBackendService) GetAccountStateChanges(ctx context.Context, address, network string, p types.AccountHistoryParams) (_ *types.PaginatedResponse[wbtypes.StateChangeNode], err error) {
+	start := time.Now()
+	defer func() { w.recordWBCall("GetAccountStateChanges", network, start, err) }()
+
+	client := w.configureNetworkClient(network)
+	if client == nil {
+		return nil, fmt.Errorf("wallet backend client not configured for network: %s", network)
+	}
+
+	first, last, after, before := translateParams(p)
+	conn, err := client.GetAccountStateChanges(ctx, address, nil, nil, nil, nil, p.Since, p.Until, first, last, after, before)
+	if err != nil {
+		if errors.Is(err, wbclient.ErrAccountNotFound) {
+			return nil, err
+		}
+		return nil, classifyWBError(err)
+	}
+	if conn == nil {
+		return emptyStateChangePage(), nil
+	}
+
+	nodes := make([]wbtypes.StateChangeNode, 0, len(conn.Edges))
+	for _, e := range conn.Edges {
+		if e.Node == nil {
+			continue
+		}
+		nodes = append(nodes, e.Node)
+	}
+	return &types.PaginatedResponse[wbtypes.StateChangeNode]{
+		Data:       nodes,
+		Pagination: toPaginationInfo(conn.PageInfo),
+	}, nil
 }
 
 // classifyWBError wraps a systemic wbclient error with an UpstreamError so

--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -1,5 +1,5 @@
 // ABOUTME: Wallet-backend service implementation that wraps the wbclient SDK and exposes the methods used by API handlers.
-// ABOUTME: Hosts the multi-account balances fan-out: per-request bounded concurrency over the per-address GraphQL query.
+// ABOUTME: Hosts the balances fan-out and the per-account history methods (transactions / operations / state-changes), sharing translate/page-info helpers.
 package services
 
 import (

--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -246,8 +246,13 @@ func translateParams(p types.AccountHistoryParams) (first, last *int32, after, b
 
 // toPaginationInfo copies an upstream PageInfo into the freighter-backend
 // response envelope shape. Cursors that the SDK omits (HasNextPage=false /
-// HasPreviousPage=false) are returned as nil pointers per the spec.
+// HasPreviousPage=false) are returned as nil pointers per the spec. A nil pi
+// returns a zero-value PaginationInfo (defense-in-depth: the SDK's connection
+// validators reject null pageInfo, but the nil-safe path costs one line).
 func toPaginationInfo(pi *wbtypes.PageInfo) types.PaginationInfo {
+	if pi == nil {
+		return types.PaginationInfo{}
+	}
 	out := types.PaginationInfo{
 		HasNext:     pi.HasNextPage,
 		HasPrevious: pi.HasPreviousPage,

--- a/internal/services/wallet_backend_test.go
+++ b/internal/services/wallet_backend_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/pkg/wbclient"
-	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
 
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/types"
@@ -607,43 +606,43 @@ func newTxFakeServer(t *testing.T, respond txResponder) *httptest.Server {
 func TestGetAccountTransactions(t *testing.T) {
 	const addr = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
 
-	t.Run("happy path returns paginated response with translated cursors", func(t *testing.T) {
+	// nestedEdgeJSON is one edge of the AccountTransactionConnection. operations
+	// and stateChanges MUST be non-null — the SDK's UnmarshalJSON rejects nulls.
+	const happyBody = `{
+		"data": {"accountByAddress": {"transactions": {
+			"edges": [
+				{"cursor": "cur-1", "node": {"hash": "h1", "feeCharged": 100, "resultCode": "tx_success", "ledgerNumber": 42, "ledgerCreatedAt": "2026-01-01T00:00:00Z", "isFeeBump": false, "ingestedAt": "2026-01-01T00:00:01Z"},
+				 "operations": [{"id": 7, "operationType": "PAYMENT", "operationXdr": "AAA", "resultCode": "op_success", "successful": true, "ledgerNumber": 42, "ledgerCreatedAt": "2026-01-01T00:00:00Z", "ingestedAt": "2026-01-01T00:00:01Z"}],
+				 "stateChanges": [{"__typename": "StandardBalanceChange", "type": "BALANCE", "reason": "DEBIT", "ledgerNumber": 42, "ledgerCreatedAt": "2026-01-01T00:00:00Z", "ingestedAt": "2026-01-01T00:00:01Z", "standardBalanceTokenId": "native", "amount": "10"}]}
+			],
+			"pageInfo": {"startCursor": "cur-1", "endCursor": "cur-1", "hasNextPage": true, "hasPreviousPage": true}
+		}}}
+	}`
+
+	t.Run("happy path maps nested edges into AccountTransaction", func(t *testing.T) {
 		t.Parallel()
 		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
 			assert.EqualValues(t, 20, vars["first"])
 			assert.Equal(t, "cur-prev", vars["after"])
-			_, hasLast := vars["last"]
-			_, hasBefore := vars["before"]
-			assert.False(t, hasLast)
-			assert.False(t, hasBefore)
-			return 200, `{
-				"data": {
-					"accountByAddress": {
-						"transactions": {
-							"edges": [
-								{"cursor": "cur-1", "node": {"hash": "h1", "feeCharged": 100, "resultCode": "tx_success", "ledgerNumber": 42, "ledgerCreatedAt": "2026-01-01T00:00:00Z", "isFeeBump": false, "ingestedAt": "2026-01-01T00:00:01Z"}}
-							],
-							"pageInfo": {"startCursor": "cur-1", "endCursor": "cur-1", "hasNextPage": true, "hasPreviousPage": true}
-						}
-					}
-				}
-			}`
+			return 200, happyBody
 		})
 		defer server.Close()
 
 		svc := newTestWalletBackendService(t, server.URL)
 		cursor := "cur-prev"
 		got, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
-			Limit:     20,
-			Cursor:    &cursor,
-			Direction: types.PaginationDirectionNext,
+			Limit: 20, Cursor: &cursor, Direction: types.PaginationDirectionNext,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, got)
 		require.Len(t, got.Data, 1)
 		assert.Equal(t, "h1", got.Data[0].Hash)
+		require.Len(t, got.Data[0].Operations, 1)
+		assert.Equal(t, int64(7), got.Data[0].Operations[0].ID)
+		assert.Equal(t, "PAYMENT", got.Data[0].Operations[0].OperationType)
+		require.Len(t, got.Data[0].StateChanges, 1)
+		require.IsType(t, &types.StandardBalanceChange{}, got.Data[0].StateChanges[0])
 		assert.True(t, got.Pagination.HasNext)
-		assert.True(t, got.Pagination.HasPrevious)
 		require.NotNil(t, got.Pagination.NextCursor)
 		assert.Equal(t, "cur-1", *got.Pagination.NextCursor)
 	})
@@ -653,21 +652,12 @@ func TestGetAccountTransactions(t *testing.T) {
 		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
 			assert.EqualValues(t, 5, vars["last"])
 			assert.Equal(t, "cur-end", vars["before"])
-			_, hasFirst := vars["first"]
-			_, hasAfter := vars["after"]
-			assert.False(t, hasFirst)
-			assert.False(t, hasAfter)
 			return 200, `{"data":{"accountByAddress":{"transactions":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`
 		})
 		defer server.Close()
-
 		svc := newTestWalletBackendService(t, server.URL)
 		cursor := "cur-end"
-		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
-			Limit:     5,
-			Cursor:    &cursor,
-			Direction: types.PaginationDirectionPrev,
-		})
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 5, Cursor: &cursor, Direction: types.PaginationDirectionPrev})
 		require.NoError(t, err)
 	})
 
@@ -677,7 +667,6 @@ func TestGetAccountTransactions(t *testing.T) {
 			return 200, `{"data":{"accountByAddress":null}}`
 		})
 		defer server.Close()
-
 		svc := newTestWalletBackendService(t, server.URL)
 		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
 		require.Error(t, err)
@@ -690,7 +679,6 @@ func TestGetAccountTransactions(t *testing.T) {
 			return 200, `{"errors":[{"message":"schema bug"}]}`
 		})
 		defer server.Close()
-
 		svc := newTestWalletBackendService(t, server.URL)
 		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
 		require.Error(t, err)
@@ -702,51 +690,36 @@ func TestGetAccountTransactions(t *testing.T) {
 	t.Run("forwards since and until to wbclient when provided", func(t *testing.T) {
 		t.Parallel()
 		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
-			// wbclient marshals time.Time values into the GraphQL variables map as
-			// RFC3339 strings; after JSON round-trip through the fake server they
-			// come back as strings, not time.Time.
 			assert.Equal(t, "2026-01-01T00:00:00Z", vars["since"])
 			assert.Equal(t, "2026-02-01T00:00:00Z", vars["until"])
 			return 200, `{"data":{"accountByAddress":{"transactions":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`
 		})
 		defer server.Close()
-
 		svc := newTestWalletBackendService(t, server.URL)
 		since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 		until := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
-			Limit:     20,
-			Direction: types.PaginationDirectionNext,
-			Since:     &since,
-			Until:     &until,
-		})
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext, Since: &since, Until: &until})
 		require.NoError(t, err)
 	})
 
 	t.Run("transport failure surfaces unwrapped (handler maps it to 502)", func(t *testing.T) {
 		t.Parallel()
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		}))
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
 		serverURL := server.URL
 		server.Close()
-
 		svc := newTestWalletBackendService(t, serverURL)
 		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
 		require.Error(t, err)
 		var upErr *metrics.UpstreamError
 		assert.False(t, errors.As(err, &upErr), "expected unwrapped transport error, got %T", err)
 		var urlErr *url.Error
-		assert.True(t, errors.As(err, &urlErr), "expected *url.Error somewhere in the chain, got %T", err)
+		assert.True(t, errors.As(err, &urlErr), "expected *url.Error in chain, got %T", err)
 	})
 
 	t.Run("HTTP 503 from upstream is wrapped as http_error with code", func(t *testing.T) {
 		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 503, `service unavailable`
-		})
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) { return 503, `service unavailable` })
 		defer server.Close()
-
 		svc := newTestWalletBackendService(t, server.URL)
 		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
 		require.Error(t, err)
@@ -756,60 +729,18 @@ func TestGetAccountTransactions(t *testing.T) {
 		assert.Equal(t, 503, upErr.Code)
 	})
 
-	t.Run("null transactions connection on existing account returns empty page", func(t *testing.T) {
+	t.Run("null transactions connection returns empty page", func(t *testing.T) {
 		t.Parallel()
 		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
 			return 200, `{"data":{"accountByAddress":{"transactions":null}}}`
 		})
 		defer server.Close()
-
 		svc := newTestWalletBackendService(t, server.URL)
 		got, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
 		require.NoError(t, err)
 		require.NotNil(t, got)
-		assert.Equal(t, []*wbtypes.GraphQLTransaction{}, got.Data)
+		assert.Equal(t, []*types.AccountTransaction{}, got.Data)
 		assert.False(t, got.Pagination.HasNext)
-		assert.False(t, got.Pagination.HasPrevious)
-		assert.Nil(t, got.Pagination.NextCursor)
-		assert.Nil(t, got.Pagination.PrevCursor)
-	})
-
-	t.Run("edges with nil node entries are skipped", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":{"transactions":{
-				"edges":[
-					{"cursor":"a","node":null},
-					{"cursor":"b","node":{"hash":"h1","feeCharged":100,"resultCode":"tx_success","ledgerNumber":42,"ledgerCreatedAt":"2026-01-01T00:00:00Z","isFeeBump":false,"ingestedAt":"2026-01-01T00:00:01Z"}}
-				],
-				"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}
-			}}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		got, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		require.Len(t, got.Data, 1)
-		assert.Equal(t, "h1", got.Data[0].Hash)
-	})
-
-	t.Run("nil edges slice (omitted on null) returns empty page", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":{"transactions":{
-				"edges":null,
-				"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}
-			}}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		got, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		assert.Equal(t, []*wbtypes.GraphQLTransaction{}, got.Data)
 	})
 
 	t.Run("ErrAccountNotFound does not increment ErrorsTotal", func(t *testing.T) {
@@ -818,398 +749,13 @@ func TestGetAccountTransactions(t *testing.T) {
 			return 200, `{"data":{"accountByAddress":null}}`
 		})
 		defer server.Close()
-
 		reg := prometheus.NewRegistry()
 		svcMetrics := metrics.NewService(reg)
 		svc := newTestWalletBackendServiceWithMetrics(t, server.URL, svcMetrics)
 		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
-
 		assert.Equal(t, float64(1), testutilCounterValue(t, reg, "freighter_service_calls_total", map[string]string{"service": "wallet-backend", "method": "GetAccountTransactions", "network": types.PUBLIC}))
-		assert.Equal(t, float64(0), testutilCounterValue(t, reg, "freighter_service_errors_total", nil))
-	})
-}
-
-func TestGetAccountOperations(t *testing.T) {
-	const addr = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
-
-	// happyOpBody is the canonical single-operation response reused by several
-	// sub-tests that need a non-empty result.
-	const happyOpBody = `{"data":{"accountByAddress":{"operations":{` +
-		`"edges":[{"cursor":"op-1","node":{"id":1,"operationType":"PAYMENT","operationXdr":"AAAA","resultCode":"op_success","successful":true,"ledgerNumber":42,"ledgerCreatedAt":"2026-01-01T00:00:00Z","ingestedAt":"2026-01-01T00:00:01Z"}}],` +
-		`"pageInfo":{"startCursor":"op-1","endCursor":"op-1","hasNextPage":true,"hasPreviousPage":true}` +
-		`}}}}`
-
-	t.Run("happy path returns paginated response with translated cursors", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
-			// direction=next → first+after; no last/before
-			assert.EqualValues(t, 20, vars["first"])
-			assert.Equal(t, "cur-prev", vars["after"])
-			_, hasLast := vars["last"]
-			_, hasBefore := vars["before"]
-			assert.False(t, hasLast)
-			assert.False(t, hasBefore)
-			return 200, happyOpBody
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		cursor := "cur-prev"
-		got, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
-			Limit:     20,
-			Cursor:    &cursor,
-			Direction: types.PaginationDirectionNext,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		require.Len(t, got.Data, 1)
-		assert.Equal(t, int64(1), got.Data[0].ID)
-		assert.Equal(t, wbtypes.OperationTypePayment, got.Data[0].OperationType)
-		assert.True(t, got.Pagination.HasNext)
-		assert.True(t, got.Pagination.HasPrevious)
-		require.NotNil(t, got.Pagination.NextCursor)
-		assert.Equal(t, "op-1", *got.Pagination.NextCursor)
-	})
-
-	t.Run("direction=prev translates to last/before", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
-			assert.EqualValues(t, 5, vars["last"])
-			assert.Equal(t, "cur-end", vars["before"])
-			_, hasFirst := vars["first"]
-			_, hasAfter := vars["after"]
-			assert.False(t, hasFirst)
-			assert.False(t, hasAfter)
-			return 200, `{"data":{"accountByAddress":{"operations":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		cursor := "cur-end"
-		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
-			Limit:     5,
-			Cursor:    &cursor,
-			Direction: types.PaginationDirectionPrev,
-		})
-		require.NoError(t, err)
-	})
-
-	t.Run("accountByAddress null returns ErrAccountNotFound", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":null}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
-	})
-
-	t.Run("GraphQL errors are wrapped as graphql_error", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"errors":[{"message":"schema bug"}]}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.Error(t, err)
-		var upErr *metrics.UpstreamError
-		require.True(t, errors.As(err, &upErr))
-		assert.Equal(t, "graphql_error", upErr.Kind)
-	})
-
-	t.Run("HTTP 503 from upstream is wrapped as http_error with code", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 503, `service unavailable`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.Error(t, err)
-		var upErr *metrics.UpstreamError
-		require.True(t, errors.As(err, &upErr))
-		assert.Equal(t, "http_error", upErr.Kind)
-		assert.Equal(t, 503, upErr.Code)
-	})
-
-	t.Run("null operations connection on existing account returns empty page", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":{"operations":null}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		got, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		assert.Equal(t, []*wbtypes.Operation{}, got.Data)
-		assert.False(t, got.Pagination.HasNext)
-		assert.False(t, got.Pagination.HasPrevious)
-		assert.Nil(t, got.Pagination.NextCursor)
-		assert.Nil(t, got.Pagination.PrevCursor)
-	})
-
-	t.Run("edges with nil node entries are skipped", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":{"operations":{` +
-				`"edges":[` +
-				`{"cursor":"a","node":null},` +
-				`{"cursor":"b","node":{"id":1,"operationType":"PAYMENT","operationXdr":"AAAA","resultCode":"op_success","successful":true,"ledgerNumber":42,"ledgerCreatedAt":"2026-01-01T00:00:00Z","ingestedAt":"2026-01-01T00:00:01Z"}}` +
-				`],` +
-				`"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}` +
-				`}}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		got, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		require.Len(t, got.Data, 1)
-		assert.Equal(t, int64(1), got.Data[0].ID)
-	})
-
-	t.Run("nil edges slice returns empty page", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":{"operations":{` +
-				`"edges":null,` +
-				`"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}` +
-				`}}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		got, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		assert.Equal(t, []*wbtypes.Operation{}, got.Data)
-	})
-
-	t.Run("ErrAccountNotFound does not increment ErrorsTotal", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":null}}`
-		})
-		defer server.Close()
-
-		reg := prometheus.NewRegistry()
-		svcMetrics := metrics.NewService(reg)
-		svc := newTestWalletBackendServiceWithMetrics(t, server.URL, svcMetrics)
-		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
-
-		assert.Equal(t, float64(1), testutilCounterValue(t, reg, "freighter_service_calls_total", map[string]string{"service": "wallet-backend", "method": "GetAccountOperations", "network": types.PUBLIC}))
-		assert.Equal(t, float64(0), testutilCounterValue(t, reg, "freighter_service_errors_total", nil))
-	})
-}
-
-func TestGetAccountStateChanges(t *testing.T) {
-	const addr = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
-
-	// happyScBody is the canonical single-state-change response reused by several
-	// sub-tests that need a non-empty result. Uses StandardBalanceChange — the
-	// simplest concrete type — so the __typename discriminator is exercised.
-	const happyScBody = `{"data":{"accountByAddress":{"stateChanges":{` +
-		`"edges":[{"cursor":"sc-1","node":{` +
-		`"__typename":"StandardBalanceChange",` +
-		`"type":"BALANCE","reason":"CREDIT",` +
-		`"ingestedAt":"2026-01-01T00:00:01Z",` +
-		`"ledgerCreatedAt":"2026-01-01T00:00:00Z",` +
-		`"ledgerNumber":42,` +
-		`"standardBalanceTokenId":"native","amount":"100"` +
-		`}}],` +
-		`"pageInfo":{"startCursor":"sc-1","endCursor":"sc-1","hasNextPage":false,"hasPreviousPage":false}` +
-		`}}}}`
-
-	t.Run("happy path returns paginated response and filter args are absent", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
-			// direction=next → first+after; no last/before
-			assert.EqualValues(t, 20, vars["first"])
-			assert.Equal(t, "cur-prev", vars["after"])
-			_, hasLast := vars["last"]
-			_, hasBefore := vars["before"]
-			assert.False(t, hasLast)
-			assert.False(t, hasBefore)
-			// The four state-change filter args must NOT be sent when they are nil.
-			_, hasTransactionHash := vars["transactionHash"]
-			_, hasOperationId := vars["operationId"]
-			_, hasCategory := vars["category"]
-			_, hasReason := vars["reason"]
-			assert.False(t, hasTransactionHash, "transactionHash must be absent when nil")
-			assert.False(t, hasOperationId, "operationId must be absent when nil")
-			assert.False(t, hasCategory, "category must be absent when nil")
-			assert.False(t, hasReason, "reason must be absent when nil")
-			return 200, happyScBody
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		cursor := "cur-prev"
-		got, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
-			Limit:     20,
-			Cursor:    &cursor,
-			Direction: types.PaginationDirectionNext,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		require.Len(t, got.Data, 1)
-		assert.Equal(t, wbtypes.StateChangeCategoryBalance, got.Data[0].GetType())
-		assert.Equal(t, wbtypes.StateChangeReasonCredit, got.Data[0].GetReason())
-		assert.False(t, got.Pagination.HasNext)
-		assert.False(t, got.Pagination.HasPrevious)
-	})
-
-	t.Run("direction=prev translates to last/before", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
-			assert.EqualValues(t, 5, vars["last"])
-			assert.Equal(t, "cur-end", vars["before"])
-			_, hasFirst := vars["first"]
-			_, hasAfter := vars["after"]
-			assert.False(t, hasFirst)
-			assert.False(t, hasAfter)
-			return 200, `{"data":{"accountByAddress":{"stateChanges":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		cursor := "cur-end"
-		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
-			Limit:     5,
-			Cursor:    &cursor,
-			Direction: types.PaginationDirectionPrev,
-		})
-		require.NoError(t, err)
-	})
-
-	t.Run("accountByAddress null returns ErrAccountNotFound", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":null}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
-	})
-
-	t.Run("GraphQL errors are wrapped as graphql_error", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"errors":[{"message":"schema bug"}]}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.Error(t, err)
-		var upErr *metrics.UpstreamError
-		require.True(t, errors.As(err, &upErr))
-		assert.Equal(t, "graphql_error", upErr.Kind)
-	})
-
-	t.Run("HTTP 503 from upstream is wrapped as http_error with code", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 503, `service unavailable`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.Error(t, err)
-		var upErr *metrics.UpstreamError
-		require.True(t, errors.As(err, &upErr))
-		assert.Equal(t, "http_error", upErr.Kind)
-		assert.Equal(t, 503, upErr.Code)
-	})
-
-	t.Run("null stateChanges connection on existing account returns empty page", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":{"stateChanges":null}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		got, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		assert.Equal(t, []wbtypes.StateChangeNode{}, got.Data)
-		assert.False(t, got.Pagination.HasNext)
-		assert.False(t, got.Pagination.HasPrevious)
-		assert.Nil(t, got.Pagination.NextCursor)
-		assert.Nil(t, got.Pagination.PrevCursor)
-	})
-
-	t.Run("edges with nil node entries are skipped", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":{"stateChanges":{` +
-				`"edges":[` +
-				`{"cursor":"a","node":null},` +
-				`{"cursor":"b","node":{"__typename":"StandardBalanceChange","type":"BALANCE","reason":"CREDIT","ingestedAt":"2026-01-01T00:00:01Z","ledgerCreatedAt":"2026-01-01T00:00:00Z","ledgerNumber":42,"standardBalanceTokenId":"native","amount":"100"}}` +
-				`],` +
-				`"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}` +
-				`}}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		got, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		require.Len(t, got.Data, 1)
-		assert.Equal(t, wbtypes.StateChangeCategoryBalance, got.Data[0].GetType())
-	})
-
-	t.Run("nil edges slice returns empty page", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":{"stateChanges":{` +
-				`"edges":null,` +
-				`"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}` +
-				`}}}}`
-		})
-		defer server.Close()
-
-		svc := newTestWalletBackendService(t, server.URL)
-		got, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.NoError(t, err)
-		require.NotNil(t, got)
-		assert.Equal(t, []wbtypes.StateChangeNode{}, got.Data)
-	})
-
-	t.Run("ErrAccountNotFound does not increment ErrorsTotal", func(t *testing.T) {
-		t.Parallel()
-		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
-			return 200, `{"data":{"accountByAddress":null}}`
-		})
-		defer server.Close()
-
-		reg := prometheus.NewRegistry()
-		svcMetrics := metrics.NewService(reg)
-		svc := newTestWalletBackendServiceWithMetrics(t, server.URL, svcMetrics)
-		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
-
-		assert.Equal(t, float64(1), testutilCounterValue(t, reg, "freighter_service_calls_total", map[string]string{"service": "wallet-backend", "method": "GetAccountStateChanges", "network": types.PUBLIC}))
 		assert.Equal(t, float64(0), testutilCounterValue(t, reg, "freighter_service_errors_total", nil))
 	})
 }

--- a/internal/services/wallet_backend_test.go
+++ b/internal/services/wallet_backend_test.go
@@ -1267,3 +1267,9 @@ func testutilCounterValue(t *testing.T, g prometheus.Gatherer, name string, labe
 	}
 	return 0
 }
+
+func TestToPaginationInfo_NilSafe(t *testing.T) {
+	t.Parallel()
+	got := toPaginationInfo(nil)
+	assert.Equal(t, types.PaginationInfo{}, got, "nil pi must return zero PaginationInfo")
+}

--- a/internal/services/wallet_backend_test.go
+++ b/internal/services/wallet_backend_test.go
@@ -831,6 +831,190 @@ func TestGetAccountTransactions(t *testing.T) {
 	})
 }
 
+func TestGetAccountOperations(t *testing.T) {
+	const addr = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
+
+	// happyOpBody is the canonical single-operation response reused by several
+	// sub-tests that need a non-empty result.
+	const happyOpBody = `{"data":{"accountByAddress":{"operations":{` +
+		`"edges":[{"cursor":"op-1","node":{"id":1,"operationType":"PAYMENT","operationXdr":"AAAA","resultCode":"op_success","successful":true,"ledgerNumber":42,"ledgerCreatedAt":"2026-01-01T00:00:00Z","ingestedAt":"2026-01-01T00:00:01Z"}}],` +
+		`"pageInfo":{"startCursor":"op-1","endCursor":"op-1","hasNextPage":true,"hasPreviousPage":true}` +
+		`}}}}`
+
+	t.Run("happy path returns paginated response with translated cursors", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
+			// direction=next → first+after; no last/before
+			assert.EqualValues(t, 20, vars["first"])
+			assert.Equal(t, "cur-prev", vars["after"])
+			_, hasLast := vars["last"]
+			_, hasBefore := vars["before"]
+			assert.False(t, hasLast)
+			assert.False(t, hasBefore)
+			return 200, happyOpBody
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		cursor := "cur-prev"
+		got, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
+			Limit:     20,
+			Cursor:    &cursor,
+			Direction: types.PaginationDirectionNext,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.Data, 1)
+		assert.Equal(t, int64(1), got.Data[0].ID)
+		assert.Equal(t, wbtypes.OperationTypePayment, got.Data[0].OperationType)
+		assert.True(t, got.Pagination.HasNext)
+		assert.True(t, got.Pagination.HasPrevious)
+		require.NotNil(t, got.Pagination.NextCursor)
+		assert.Equal(t, "op-1", *got.Pagination.NextCursor)
+	})
+
+	t.Run("direction=prev translates to last/before", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
+			assert.EqualValues(t, 5, vars["last"])
+			assert.Equal(t, "cur-end", vars["before"])
+			_, hasFirst := vars["first"]
+			_, hasAfter := vars["after"]
+			assert.False(t, hasFirst)
+			assert.False(t, hasAfter)
+			return 200, `{"data":{"accountByAddress":{"operations":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		cursor := "cur-end"
+		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
+			Limit:     5,
+			Cursor:    &cursor,
+			Direction: types.PaginationDirectionPrev,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("accountByAddress null returns ErrAccountNotFound", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":null}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
+	})
+
+	t.Run("GraphQL errors are wrapped as graphql_error", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"errors":[{"message":"schema bug"}]}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		var upErr *metrics.UpstreamError
+		require.True(t, errors.As(err, &upErr))
+		assert.Equal(t, "graphql_error", upErr.Kind)
+	})
+
+	t.Run("HTTP 503 from upstream is wrapped as http_error with code", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 503, `service unavailable`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		var upErr *metrics.UpstreamError
+		require.True(t, errors.As(err, &upErr))
+		assert.Equal(t, "http_error", upErr.Kind)
+		assert.Equal(t, 503, upErr.Code)
+	})
+
+	t.Run("null operations connection on existing account returns empty page", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"operations":null}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []*wbtypes.Operation{}, got.Data)
+		assert.False(t, got.Pagination.HasNext)
+		assert.False(t, got.Pagination.HasPrevious)
+		assert.Nil(t, got.Pagination.NextCursor)
+		assert.Nil(t, got.Pagination.PrevCursor)
+	})
+
+	t.Run("edges with nil node entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"operations":{` +
+				`"edges":[` +
+				`{"cursor":"a","node":null},` +
+				`{"cursor":"b","node":{"id":1,"operationType":"PAYMENT","operationXdr":"AAAA","resultCode":"op_success","successful":true,"ledgerNumber":42,"ledgerCreatedAt":"2026-01-01T00:00:00Z","ingestedAt":"2026-01-01T00:00:01Z"}}` +
+				`],` +
+				`"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}` +
+				`}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.Data, 1)
+		assert.Equal(t, int64(1), got.Data[0].ID)
+	})
+
+	t.Run("nil edges slice returns empty page", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"operations":{` +
+				`"edges":null,` +
+				`"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}` +
+				`}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []*wbtypes.Operation{}, got.Data)
+	})
+
+	t.Run("ErrAccountNotFound does not increment ErrorsTotal", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":null}}`
+		})
+		defer server.Close()
+
+		reg := prometheus.NewRegistry()
+		svcMetrics := metrics.NewService(reg)
+		svc := newTestWalletBackendServiceWithMetrics(t, server.URL, svcMetrics)
+		_, err := svc.GetAccountOperations(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
+
+		assert.Equal(t, float64(1), testutilCounterValue(t, reg, "freighter_service_calls_total", map[string]string{"service": "wallet-backend", "method": "GetAccountOperations", "network": types.PUBLIC}))
+		assert.Equal(t, float64(0), testutilCounterValue(t, reg, "freighter_service_errors_total", nil))
+	})
+}
+
 // newTestWalletBackendService builds a walletBackendService configured against the
 // given pubnet URL, with no metrics (test helper for non-metrics tests).
 func newTestWalletBackendService(t *testing.T, pubnetURL string) types.WalletBackendService {

--- a/internal/services/wallet_backend_test.go
+++ b/internal/services/wallet_backend_test.go
@@ -248,10 +248,11 @@ func paginatedNativeBalanceResponse(amount, endCursor string, hasNext bool) stri
 	}`, amount, hasNext, cursorJSON)
 }
 
-// newFanoutTestService builds a walletBackendService directly,
-// bypassing NewWalletBackendService so we can wire a no-signer wbclient
-// pointed at the fake server. Tests live in the services package, so the
-// unexported struct is accessible.
+// newFanoutTestService builds a walletBackendService by direct struct construction
+// so the fan-out tests below can access internal atomics on fanoutFakeServer
+// (peak / calls / inflight). New tests that don't need direct struct access
+// should use newTestWalletBackendService instead — it exercises the real
+// NewWalletBackendService constructor and returns the interface type.
 func newFanoutTestService(baseURL string, maxConcurrency int) *walletBackendService {
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	client := wbclient.NewClient(baseURL, nil) // nil signer is fine — wbclient skips signing when nil
@@ -701,6 +702,9 @@ func TestGetAccountTransactions(t *testing.T) {
 	t.Run("forwards since and until to wbclient when provided", func(t *testing.T) {
 		t.Parallel()
 		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
+			// wbclient marshals time.Time values into the GraphQL variables map as
+			// RFC3339 strings; after JSON round-trip through the fake server they
+			// come back as strings, not time.Time.
 			assert.Equal(t, "2026-01-01T00:00:00Z", vars["since"])
 			assert.Equal(t, "2026-02-01T00:00:00Z", vars["until"])
 			return 200, `{"data":{"accountByAddress":{"transactions":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`

--- a/internal/services/wallet_backend_test.go
+++ b/internal/services/wallet_backend_test.go
@@ -1,5 +1,5 @@
-// ABOUTME: Unit tests for the wallet-backend service constructor, error classification, and balances fan-out.
-// ABOUTME: Uses httptest.Server fakes to exercise GetBalancesByAccountAddresses without a real wallet-backend.
+// ABOUTME: Unit tests for the wallet-backend service constructor, error classification, balances fan-out, and account history.
+// ABOUTME: Uses httptest.Server fakes to exercise service methods without a real wallet-backend.
 package services
 
 import (
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/wallet-backend/pkg/wbclient"
+	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
 
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/types"
@@ -246,11 +248,11 @@ func paginatedNativeBalanceResponse(amount, endCursor string, hasNext bool) stri
 	}`, amount, hasNext, cursorJSON)
 }
 
-// newTestWalletBackendService builds a walletBackendService directly,
+// newFanoutTestService builds a walletBackendService directly,
 // bypassing NewWalletBackendService so we can wire a no-signer wbclient
 // pointed at the fake server. Tests live in the services package, so the
 // unexported struct is accessible.
-func newTestWalletBackendService(baseURL string, maxConcurrency int) *walletBackendService {
+func newFanoutTestService(baseURL string, maxConcurrency int) *walletBackendService {
 	httpClient := &http.Client{Timeout: 30 * time.Second}
 	client := wbclient.NewClient(baseURL, nil) // nil signer is fine — wbclient skips signing when nil
 	client.HTTPClient = httpClient
@@ -282,7 +284,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 			t.Fatalf("unexpected address %q", address)
 			return 0, ""
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA, addrB}, types.PUBLIC)
 		require.NoError(t, err)
@@ -316,7 +318,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 			}
 			return http.StatusOK, paginatedNativeBalanceResponse("20.0000000", "", false)
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA}, types.PUBLIC)
 		require.NoError(t, err)
@@ -343,7 +345,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 			}
 			return http.StatusOK, nativeBalanceGraphQLResponse("50.0000000")
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA, addrB}, types.PUBLIC)
 		require.Error(t, err)
@@ -365,7 +367,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 			}
 			return http.StatusOK, nativeBalanceGraphQLResponse("25.0000000")
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA, addrB}, types.PUBLIC)
 		require.NoError(t, err)
@@ -394,7 +396,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 			}
 			return http.StatusOK, nativeBalanceGraphQLResponse("75.0000000")
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA, addrB}, types.PUBLIC)
 		require.Error(t, err)
@@ -412,7 +414,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 			}
 			return http.StatusOK, nativeBalanceGraphQLResponse("100.0000000")
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA, addrB}, types.PUBLIC)
 		require.Error(t, err, "5xx must surface as a top-level error so monitoring catches outages")
@@ -427,7 +429,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 		f := newFanoutFakeServer(t, func(address string, _ *string) (int, string) {
 			return http.StatusOK, nativeBalanceGraphQLResponse("100.0000000")
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 		// Close before calling so every request errors at the transport layer
 		// (connection refused). Transport errors must propagate top-level —
 		// turning them into per-account strings would hide outages.
@@ -441,7 +443,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 		f := newFanoutFakeServer(t, func(_ string, _ *string) (int, string) {
 			return http.StatusOK, emptyBalancesGraphQLResponse()
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA}, types.PUBLIC)
 		require.NoError(t, err)
@@ -472,7 +474,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 			<-release
 			return http.StatusOK, nativeBalanceGraphQLResponse("1.0000000")
 		})
-		svc := newTestWalletBackendService(f.server.URL, limit)
+		svc := newFanoutTestService(f.server.URL, limit)
 
 		addrs := []string{
 			"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
@@ -551,7 +553,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 			time.Sleep(500 * time.Millisecond)
 			return http.StatusOK, nativeBalanceGraphQLResponse("1.0000000")
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
@@ -563,7 +565,7 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 		f := newFanoutFakeServer(t, func(address string, _ *string) (int, string) {
 			return http.StatusOK, nativeBalanceGraphQLResponse("1.0000000")
 		})
-		svc := newTestWalletBackendService(f.server.URL, 10)
+		svc := newFanoutTestService(f.server.URL, 10)
 
 		raw, err := svc.GetBalancesByAccountAddresses(
 			context.Background(),
@@ -577,4 +579,304 @@ func TestGetBalancesByAccountAddresses_FanOut(t *testing.T) {
 		assert.Equal(t, addrB, results[1].Address)
 		assert.Equal(t, int64(2), f.calls.Load(), "fake server must see exactly len(unique) GraphQL calls")
 	})
+}
+
+// txResponder builds a fake response for the GetAccountTransactions GraphQL query.
+type txResponder func(address string, vars map[string]interface{}) (status int, body string)
+
+// newTxFakeServer creates an httptest.Server that routes GraphQL requests through a txResponder.
+// It unmarshals the full variables map so tests can assert on any variable (first, last, after,
+// before, since, until) without a separate extractor helper.
+func newTxFakeServer(t *testing.T, respond txResponder) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql/query", func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var req wbclient.GraphQLRequest
+		require.NoError(t, json.Unmarshal(bodyBytes, &req))
+		addr, _ := req.Variables["address"].(string)
+		status, body := respond(addr, req.Variables)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestGetAccountTransactions(t *testing.T) {
+	const addr = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
+
+	t.Run("happy path returns paginated response with translated cursors", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
+			assert.EqualValues(t, 20, vars["first"])
+			assert.Equal(t, "cur-prev", vars["after"])
+			_, hasLast := vars["last"]
+			_, hasBefore := vars["before"]
+			assert.False(t, hasLast)
+			assert.False(t, hasBefore)
+			return 200, `{
+				"data": {
+					"accountByAddress": {
+						"transactions": {
+							"edges": [
+								{"cursor": "cur-1", "node": {"hash": "h1", "feeCharged": 100, "resultCode": "tx_success", "ledgerNumber": 42, "ledgerCreatedAt": "2026-01-01T00:00:00Z", "isFeeBump": false, "ingestedAt": "2026-01-01T00:00:01Z"}}
+							],
+							"pageInfo": {"startCursor": "cur-1", "endCursor": "cur-1", "hasNextPage": true, "hasPreviousPage": true}
+						}
+					}
+				}
+			}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		cursor := "cur-prev"
+		got, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
+			Limit:     20,
+			Cursor:    &cursor,
+			Direction: types.PaginationDirectionNext,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.Data, 1)
+		assert.Equal(t, "h1", got.Data[0].Hash)
+		assert.True(t, got.Pagination.HasNext)
+		assert.True(t, got.Pagination.HasPrevious)
+		require.NotNil(t, got.Pagination.NextCursor)
+		assert.Equal(t, "cur-1", *got.Pagination.NextCursor)
+	})
+
+	t.Run("direction=prev translates to last/before", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
+			assert.EqualValues(t, 5, vars["last"])
+			assert.Equal(t, "cur-end", vars["before"])
+			_, hasFirst := vars["first"]
+			_, hasAfter := vars["after"]
+			assert.False(t, hasFirst)
+			assert.False(t, hasAfter)
+			return 200, `{"data":{"accountByAddress":{"transactions":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		cursor := "cur-end"
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
+			Limit:     5,
+			Cursor:    &cursor,
+			Direction: types.PaginationDirectionPrev,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("accountByAddress null returns ErrAccountNotFound", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":null}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
+	})
+
+	t.Run("GraphQL errors are wrapped as graphql_error", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"errors":[{"message":"schema bug"}]}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		var upErr *metrics.UpstreamError
+		require.True(t, errors.As(err, &upErr))
+		assert.Equal(t, "graphql_error", upErr.Kind)
+	})
+
+	t.Run("forwards since and until to wbclient when provided", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
+			assert.Equal(t, "2026-01-01T00:00:00Z", vars["since"])
+			assert.Equal(t, "2026-02-01T00:00:00Z", vars["until"])
+			return 200, `{"data":{"accountByAddress":{"transactions":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
+			Limit:     20,
+			Direction: types.PaginationDirectionNext,
+			Since:     &since,
+			Until:     &until,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("transport failure surfaces unwrapped (handler maps it to 502)", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		serverURL := server.URL
+		server.Close()
+
+		svc := newTestWalletBackendService(t, serverURL)
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		var upErr *metrics.UpstreamError
+		assert.False(t, errors.As(err, &upErr), "expected unwrapped transport error, got %T", err)
+		var urlErr *url.Error
+		assert.True(t, errors.As(err, &urlErr), "expected *url.Error somewhere in the chain, got %T", err)
+	})
+
+	t.Run("HTTP 503 from upstream is wrapped as http_error with code", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 503, `service unavailable`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		var upErr *metrics.UpstreamError
+		require.True(t, errors.As(err, &upErr))
+		assert.Equal(t, "http_error", upErr.Kind)
+		assert.Equal(t, 503, upErr.Code)
+	})
+
+	t.Run("null transactions connection on existing account returns empty page", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"transactions":null}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []*wbtypes.GraphQLTransaction{}, got.Data)
+		assert.False(t, got.Pagination.HasNext)
+		assert.False(t, got.Pagination.HasPrevious)
+		assert.Nil(t, got.Pagination.NextCursor)
+		assert.Nil(t, got.Pagination.PrevCursor)
+	})
+
+	t.Run("edges with nil node entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"transactions":{
+				"edges":[
+					{"cursor":"a","node":null},
+					{"cursor":"b","node":{"hash":"h1","feeCharged":100,"resultCode":"tx_success","ledgerNumber":42,"ledgerCreatedAt":"2026-01-01T00:00:00Z","isFeeBump":false,"ingestedAt":"2026-01-01T00:00:01Z"}}
+				],
+				"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}
+			}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.Data, 1)
+		assert.Equal(t, "h1", got.Data[0].Hash)
+	})
+
+	t.Run("nil edges slice (omitted on null) returns empty page", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"transactions":{
+				"edges":null,
+				"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}
+			}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []*wbtypes.GraphQLTransaction{}, got.Data)
+	})
+
+	t.Run("ErrAccountNotFound does not increment ErrorsTotal", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":null}}`
+		})
+		defer server.Close()
+
+		reg := prometheus.NewRegistry()
+		svcMetrics := metrics.NewService(reg)
+		svc := newTestWalletBackendServiceWithMetrics(t, server.URL, svcMetrics)
+		_, err := svc.GetAccountTransactions(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
+
+		assert.Equal(t, float64(1), testutilCounterValue(t, reg, "freighter_service_calls_total", map[string]string{"service": "wallet-backend", "method": "GetAccountTransactions", "network": types.PUBLIC}))
+		assert.Equal(t, float64(0), testutilCounterValue(t, reg, "freighter_service_errors_total", nil))
+	})
+}
+
+// newTestWalletBackendService builds a walletBackendService configured against the
+// given pubnet URL, with no metrics (test helper for non-metrics tests).
+func newTestWalletBackendService(t *testing.T, pubnetURL string) types.WalletBackendService {
+	return newTestWalletBackendServiceWithMetrics(t, pubnetURL, nil)
+}
+
+// newTestWalletBackendServiceWithMetrics builds a walletBackendService configured against
+// the given pubnet URL, wiring the provided metrics.Service (may be nil).
+func newTestWalletBackendServiceWithMetrics(t *testing.T, pubnetURL string, svcMetrics *metrics.Service) types.WalletBackendService {
+	t.Helper()
+	const signingKey = "SBLIQC4PO4OJDNAUGJJL23H7HWME4VCW4PFAPIJ6SI4HHEYKJ2QO32HN"
+	svc, err := NewWalletBackendService(pubnetURL, "", signingKey, "", 10, svcMetrics)
+	require.NoError(t, err)
+	return svc
+}
+
+// testutilCounterValue returns the summed value of a Prometheus counter (or
+// CounterVec total when labels is nil) registered in the given Gatherer.
+func testutilCounterValue(t *testing.T, g prometheus.Gatherer, name string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := g.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		var total float64
+		for _, m := range mf.GetMetric() {
+			if labels != nil {
+				matched := true
+				for k, v := range labels {
+					found := false
+					for _, lp := range m.GetLabel() {
+						if lp.GetName() == k && lp.GetValue() == v {
+							found = true
+							break
+						}
+					}
+					if !found {
+						matched = false
+						break
+					}
+				}
+				if !matched {
+					continue
+				}
+			}
+			total += m.GetCounter().GetValue()
+		}
+		return total
+	}
+	return 0
 }

--- a/internal/services/wallet_backend_test.go
+++ b/internal/services/wallet_backend_test.go
@@ -1015,6 +1015,205 @@ func TestGetAccountOperations(t *testing.T) {
 	})
 }
 
+func TestGetAccountStateChanges(t *testing.T) {
+	const addr = "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF"
+
+	// happyScBody is the canonical single-state-change response reused by several
+	// sub-tests that need a non-empty result. Uses StandardBalanceChange — the
+	// simplest concrete type — so the __typename discriminator is exercised.
+	const happyScBody = `{"data":{"accountByAddress":{"stateChanges":{` +
+		`"edges":[{"cursor":"sc-1","node":{` +
+		`"__typename":"StandardBalanceChange",` +
+		`"type":"BALANCE","reason":"CREDIT",` +
+		`"ingestedAt":"2026-01-01T00:00:01Z",` +
+		`"ledgerCreatedAt":"2026-01-01T00:00:00Z",` +
+		`"ledgerNumber":42,` +
+		`"standardBalanceTokenId":"native","amount":"100"` +
+		`}}],` +
+		`"pageInfo":{"startCursor":"sc-1","endCursor":"sc-1","hasNextPage":false,"hasPreviousPage":false}` +
+		`}}}}`
+
+	t.Run("happy path returns paginated response and filter args are absent", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
+			// direction=next → first+after; no last/before
+			assert.EqualValues(t, 20, vars["first"])
+			assert.Equal(t, "cur-prev", vars["after"])
+			_, hasLast := vars["last"]
+			_, hasBefore := vars["before"]
+			assert.False(t, hasLast)
+			assert.False(t, hasBefore)
+			// The four state-change filter args must NOT be sent when they are nil.
+			_, hasTransactionHash := vars["transactionHash"]
+			_, hasOperationId := vars["operationId"]
+			_, hasCategory := vars["category"]
+			_, hasReason := vars["reason"]
+			assert.False(t, hasTransactionHash, "transactionHash must be absent when nil")
+			assert.False(t, hasOperationId, "operationId must be absent when nil")
+			assert.False(t, hasCategory, "category must be absent when nil")
+			assert.False(t, hasReason, "reason must be absent when nil")
+			return 200, happyScBody
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		cursor := "cur-prev"
+		got, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
+			Limit:     20,
+			Cursor:    &cursor,
+			Direction: types.PaginationDirectionNext,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.Data, 1)
+		assert.Equal(t, wbtypes.StateChangeCategoryBalance, got.Data[0].GetType())
+		assert.Equal(t, wbtypes.StateChangeReasonCredit, got.Data[0].GetReason())
+		assert.False(t, got.Pagination.HasNext)
+		assert.False(t, got.Pagination.HasPrevious)
+	})
+
+	t.Run("direction=prev translates to last/before", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, vars map[string]interface{}) (int, string) {
+			assert.EqualValues(t, 5, vars["last"])
+			assert.Equal(t, "cur-end", vars["before"])
+			_, hasFirst := vars["first"]
+			_, hasAfter := vars["after"]
+			assert.False(t, hasFirst)
+			assert.False(t, hasAfter)
+			return 200, `{"data":{"accountByAddress":{"stateChanges":{"edges":[],"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		cursor := "cur-end"
+		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{
+			Limit:     5,
+			Cursor:    &cursor,
+			Direction: types.PaginationDirectionPrev,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("accountByAddress null returns ErrAccountNotFound", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":null}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
+	})
+
+	t.Run("GraphQL errors are wrapped as graphql_error", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"errors":[{"message":"schema bug"}]}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		var upErr *metrics.UpstreamError
+		require.True(t, errors.As(err, &upErr))
+		assert.Equal(t, "graphql_error", upErr.Kind)
+	})
+
+	t.Run("HTTP 503 from upstream is wrapped as http_error with code", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 503, `service unavailable`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		var upErr *metrics.UpstreamError
+		require.True(t, errors.As(err, &upErr))
+		assert.Equal(t, "http_error", upErr.Kind)
+		assert.Equal(t, 503, upErr.Code)
+	})
+
+	t.Run("null stateChanges connection on existing account returns empty page", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"stateChanges":null}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []wbtypes.StateChangeNode{}, got.Data)
+		assert.False(t, got.Pagination.HasNext)
+		assert.False(t, got.Pagination.HasPrevious)
+		assert.Nil(t, got.Pagination.NextCursor)
+		assert.Nil(t, got.Pagination.PrevCursor)
+	})
+
+	t.Run("edges with nil node entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"stateChanges":{` +
+				`"edges":[` +
+				`{"cursor":"a","node":null},` +
+				`{"cursor":"b","node":{"__typename":"StandardBalanceChange","type":"BALANCE","reason":"CREDIT","ingestedAt":"2026-01-01T00:00:01Z","ledgerCreatedAt":"2026-01-01T00:00:00Z","ledgerNumber":42,"standardBalanceTokenId":"native","amount":"100"}}` +
+				`],` +
+				`"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}` +
+				`}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Len(t, got.Data, 1)
+		assert.Equal(t, wbtypes.StateChangeCategoryBalance, got.Data[0].GetType())
+	})
+
+	t.Run("nil edges slice returns empty page", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":{"stateChanges":{` +
+				`"edges":null,` +
+				`"pageInfo":{"hasNextPage":false,"hasPreviousPage":false}` +
+				`}}}}`
+		})
+		defer server.Close()
+
+		svc := newTestWalletBackendService(t, server.URL)
+		got, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []wbtypes.StateChangeNode{}, got.Data)
+	})
+
+	t.Run("ErrAccountNotFound does not increment ErrorsTotal", func(t *testing.T) {
+		t.Parallel()
+		server := newTxFakeServer(t, func(_ string, _ map[string]interface{}) (int, string) {
+			return 200, `{"data":{"accountByAddress":null}}`
+		})
+		defer server.Close()
+
+		reg := prometheus.NewRegistry()
+		svcMetrics := metrics.NewService(reg)
+		svc := newTestWalletBackendServiceWithMetrics(t, server.URL, svcMetrics)
+		_, err := svc.GetAccountStateChanges(context.Background(), addr, types.PUBLIC, types.AccountHistoryParams{Limit: 20, Direction: types.PaginationDirectionNext})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, wbclient.ErrAccountNotFound))
+
+		assert.Equal(t, float64(1), testutilCounterValue(t, reg, "freighter_service_calls_total", map[string]string{"service": "wallet-backend", "method": "GetAccountStateChanges", "network": types.PUBLIC}))
+		assert.Equal(t, float64(0), testutilCounterValue(t, reg, "freighter_service_errors_total", nil))
+	})
+}
+
 // newTestWalletBackendService builds a walletBackendService configured against the
 // given pubnet URL, with no metrics (test helper for non-metrics tests).
 func newTestWalletBackendService(t *testing.T, pubnetURL string) types.WalletBackendService {

--- a/internal/types/account_history.go
+++ b/internal/types/account_history.go
@@ -1,0 +1,123 @@
+// ABOUTME: snake_case REST response types for GET /api/v1/accounts/{address}/transactions.
+// ABOUTME: Mirrors the wallet-backend SDK types with consistent snake_case keys and string-encoded 64-bit ints.
+package types
+
+import "time"
+
+// Transaction is the snake_case REST representation of a Stellar transaction.
+// FeeCharged is string-encoded so JavaScript clients never lose precision and
+// to match the "Stellar amounts as strings" convention used elsewhere.
+type Transaction struct {
+	Hash            string    `json:"hash"`
+	FeeCharged      int64     `json:"fee_charged,string"`
+	ResultCode      string    `json:"result_code"`
+	LedgerNumber    uint32    `json:"ledger_number"`
+	LedgerCreatedAt time.Time `json:"ledger_created_at"`
+	IsFeeBump       bool      `json:"is_fee_bump"`
+	IngestedAt      time.Time `json:"ingested_at"`
+}
+
+// Operation is the snake_case REST representation of a Stellar operation.
+// ID is a TOID that routinely exceeds 2^53, so it is string-encoded to survive
+// JSON parsing in JavaScript clients without precision loss.
+type Operation struct {
+	ID              int64     `json:"id,string"`
+	OperationType   string    `json:"operation_type"`
+	OperationXDR    string    `json:"operation_xdr"`
+	ResultCode      string    `json:"result_code"`
+	Successful      bool      `json:"successful"`
+	LedgerNumber    uint32    `json:"ledger_number"`
+	LedgerCreatedAt time.Time `json:"ledger_created_at"`
+	IngestedAt      time.Time `json:"ingested_at"`
+}
+
+// StateChange is a sealed interface implemented by every state-change variant.
+// The concrete type is determined by the StateChangeBase.Type discriminator
+// (StateChangeCategory is 1:1 with the variants), so clients switch on "type".
+type StateChange interface{ isStateChange() }
+
+// StateChangeBase holds the fields common to every state-change variant.
+type StateChangeBase struct {
+	Type            string    `json:"type"`
+	Reason          string    `json:"reason"`
+	LedgerNumber    uint32    `json:"ledger_number"`
+	LedgerCreatedAt time.Time `json:"ledger_created_at"`
+	IngestedAt      time.Time `json:"ingested_at"`
+}
+
+func (StateChangeBase) isStateChange() {}
+
+// StandardBalanceChange — category BALANCE.
+type StandardBalanceChange struct {
+	StateChangeBase
+	StandardBalanceTokenID string `json:"standard_balance_token_id"`
+	Amount                 string `json:"amount"`
+}
+
+// AccountChange — category ACCOUNT.
+type AccountChange struct {
+	StateChangeBase
+	FunderAddress *string `json:"funder_address,omitempty"`
+}
+
+// SignerChange — category SIGNER.
+type SignerChange struct {
+	StateChangeBase
+	SignerAddress *string `json:"signer_address,omitempty"`
+	SignerWeights *string `json:"signer_weights,omitempty"`
+}
+
+// SignerThresholdsChange — category SIGNATURE_THRESHOLD.
+type SignerThresholdsChange struct {
+	StateChangeBase
+	Thresholds string `json:"thresholds"`
+}
+
+// MetadataChange — category METADATA.
+type MetadataChange struct {
+	StateChangeBase
+	MetadataKeyValue string `json:"metadata_key_value"`
+}
+
+// FlagsChange — category FLAGS.
+type FlagsChange struct {
+	StateChangeBase
+	Flags []string `json:"flags"`
+}
+
+// TrustlineChange — category TRUSTLINE.
+type TrustlineChange struct {
+	StateChangeBase
+	TrustlineTokenID         *string `json:"trustline_token_id,omitempty"`
+	Limit                    *string `json:"limit,omitempty"`
+	TrustlineLiquidityPoolID *string `json:"trustline_liquidity_pool_id,omitempty"`
+}
+
+// ReservesChange — category RESERVES.
+type ReservesChange struct {
+	StateChangeBase
+	SponsoredAddress   *string `json:"sponsored_address,omitempty"`
+	SponsorAddress     *string `json:"sponsor_address,omitempty"`
+	SponsoredData      *string `json:"sponsored_data,omitempty"`
+	SponsoredTrustline *string `json:"sponsored_trustline,omitempty"`
+	ClaimableBalanceID *string `json:"claimable_balance_id,omitempty"`
+	LiquidityPoolID    *string `json:"liquidity_pool_id,omitempty"`
+}
+
+// BalanceAuthorizationChange — category BALANCE_AUTHORIZATION.
+type BalanceAuthorizationChange struct {
+	StateChangeBase
+	BalanceAuthTokenID         *string  `json:"balance_auth_token_id,omitempty"`
+	BalanceAuthLiquidityPoolID *string  `json:"balance_auth_liquidity_pool_id,omitempty"`
+	Flags                      []string `json:"flags"`
+}
+
+// AccountTransaction is one transaction plus the calling account's operations
+// and state changes within it. The embedded Transaction's fields are promoted
+// to the top level of the JSON object. Operations and StateChanges are always
+// non-nil (empty slice, never null) when built by the service mapper.
+type AccountTransaction struct {
+	Transaction
+	Operations   []Operation   `json:"operations"`
+	StateChanges []StateChange `json:"state_changes"`
+}

--- a/internal/types/account_history_internal_test.go
+++ b/internal/types/account_history_internal_test.go
@@ -1,0 +1,29 @@
+// ABOUTME: Internal package tests for account_history.go; keeps the deadcode analyser satisfied.
+// ABOUTME: The isStateChange() marker method is unexported and never called at runtime, so we call
+// it here to prevent golang.org/x/tools/cmd/deadcode from flagging it as unreachable.
+package types
+
+import "testing"
+
+// TestStateChangeBase_isStateChange exercises the sealed-interface marker method so the
+// deadcode analyser (which uses RTA and only marks a method reachable when it finds a
+// call site on an interface value) does not report StateChangeBase.isStateChange as dead.
+func TestStateChangeBase_isStateChange(t *testing.T) {
+	t.Parallel()
+	// Call the marker through each concrete type so RTA sees the dynamic dispatch.
+	variants := []StateChange{
+		StateChangeBase{},
+		&StandardBalanceChange{},
+		&AccountChange{},
+		&SignerChange{},
+		&SignerThresholdsChange{},
+		&MetadataChange{},
+		&FlagsChange{},
+		&TrustlineChange{},
+		&ReservesChange{},
+		&BalanceAuthorizationChange{},
+	}
+	for _, v := range variants {
+		v.isStateChange() // marker call — keeps deadcode happy
+	}
+}

--- a/internal/types/account_history_test.go
+++ b/internal/types/account_history_test.go
@@ -1,0 +1,74 @@
+// ABOUTME: Wire-contract tests for the snake_case account-history REST response types.
+// ABOUTME: Asserts JSON key casing, string-encoded 64-bit ints, and polymorphic state-change shape.
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/freighter-backend-v2/internal/types"
+)
+
+func TestAccountTransaction_JSONWireContract(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	funder := "GFUNDER"
+	at := types.AccountTransaction{
+		Transaction: types.Transaction{
+			Hash: "h1", FeeCharged: 100, ResultCode: "txSUCCESS",
+			LedgerNumber: 51234567, LedgerCreatedAt: ts, IsFeeBump: false, IngestedAt: ts,
+		},
+		Operations: []types.Operation{{
+			ID: 220000000000000, OperationType: "PAYMENT", OperationXDR: "AAA",
+			ResultCode: "opSUCCESS", Successful: true, LedgerNumber: 51234567,
+			LedgerCreatedAt: ts, IngestedAt: ts,
+		}},
+		StateChanges: []types.StateChange{
+			&types.StandardBalanceChange{
+				StateChangeBase:        types.StateChangeBase{Type: "BALANCE", Reason: "DEBIT", LedgerNumber: 51234567, LedgerCreatedAt: ts, IngestedAt: ts},
+				StandardBalanceTokenID: "native", Amount: "10.0000000",
+			},
+			&types.AccountChange{
+				StateChangeBase: types.StateChangeBase{Type: "ACCOUNT", Reason: "CREATE", LedgerNumber: 51234567, LedgerCreatedAt: ts, IngestedAt: ts},
+				FunderAddress:   &funder,
+			},
+		},
+	}
+	b, err := json.Marshal(at)
+	require.NoError(t, err)
+	s := string(b)
+
+	assert.Contains(t, s, `"fee_charged":"100"`)
+	assert.Contains(t, s, `"id":"220000000000000"`)
+	assert.Contains(t, s, `"ledger_number":51234567`)
+	assert.Contains(t, s, `"result_code":"txSUCCESS"`)
+	assert.Contains(t, s, `"operation_type":"PAYMENT"`)
+	assert.Contains(t, s, `"operation_xdr":"AAA"`)
+	assert.NotContains(t, s, "feeCharged")
+	assert.NotContains(t, s, "operationType")
+	assert.NotContains(t, s, "ledgerCreatedAt")
+	assert.Contains(t, s, `"state_changes":`)
+	assert.Contains(t, s, `"type":"BALANCE"`)
+	assert.Contains(t, s, `"standard_balance_token_id":"native"`)
+	assert.Contains(t, s, `"amount":"10.0000000"`)
+	assert.Contains(t, s, `"type":"ACCOUNT"`)
+	assert.Contains(t, s, `"funder_address":"GFUNDER"`)
+}
+
+func TestAccountTransaction_EmptyDetailsMarshalAsArrays(t *testing.T) {
+	t.Parallel()
+	at := types.AccountTransaction{
+		Transaction:  types.Transaction{Hash: "h1"},
+		Operations:   []types.Operation{},
+		StateChanges: []types.StateChange{},
+	}
+	b, err := json.Marshal(at)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"operations":[]`)
+	assert.Contains(t, s, `"state_changes":[]`)
+}

--- a/internal/types/interfaces.go
+++ b/internal/types/interfaces.go
@@ -3,8 +3,6 @@ package types
 import (
 	"context"
 
-	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
-
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
@@ -44,7 +42,5 @@ type RPCService interface {
 type WalletBackendService interface {
 	Service
 	GetBalancesByAccountAddresses(ctx context.Context, addresses []string, network string) (interface{}, error)
-	GetAccountTransactions(ctx context.Context, address, network string, params AccountHistoryParams) (*PaginatedResponse[*wbtypes.GraphQLTransaction], error)
-	GetAccountOperations(ctx context.Context, address, network string, params AccountHistoryParams) (*PaginatedResponse[*wbtypes.Operation], error)
-	GetAccountStateChanges(ctx context.Context, address, network string, params AccountHistoryParams) (*PaginatedResponse[wbtypes.StateChangeNode], error)
+	GetAccountTransactions(ctx context.Context, address, network string, params AccountHistoryParams) (*PaginatedResponse[*AccountTransaction], error)
 }

--- a/internal/types/interfaces.go
+++ b/internal/types/interfaces.go
@@ -3,6 +3,8 @@ package types
 import (
 	"context"
 
+	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
+
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
@@ -42,4 +44,7 @@ type RPCService interface {
 type WalletBackendService interface {
 	Service
 	GetBalancesByAccountAddresses(ctx context.Context, addresses []string, network string) (interface{}, error)
+	GetAccountTransactions(ctx context.Context, address, network string, params AccountHistoryParams) (*PaginatedResponse[*wbtypes.GraphQLTransaction], error)
+	GetAccountOperations(ctx context.Context, address, network string, params AccountHistoryParams) (*PaginatedResponse[*wbtypes.Operation], error)
+	GetAccountStateChanges(ctx context.Context, address, network string, params AccountHistoryParams) (*PaginatedResponse[wbtypes.StateChangeNode], error)
 }

--- a/internal/types/wallet_backend.go
+++ b/internal/types/wallet_backend.go
@@ -40,9 +40,9 @@ const (
 )
 
 // AccountHistoryParams carries pagination and time-range filters for the
-// account-scoped history endpoints (transactions / operations / state-changes).
-// Cursor is opaque (forwarded verbatim to wallet-backend). All time pointers
-// are nil when the caller omits the corresponding query param.
+// account-scoped transactions history endpoint. Cursor is opaque (forwarded
+// verbatim to wallet-backend). All time pointers are nil when the caller omits
+// the corresponding query param.
 type AccountHistoryParams struct {
 	Limit     int32
 	Cursor    *string

--- a/internal/types/wallet_backend.go
+++ b/internal/types/wallet_backend.go
@@ -3,6 +3,8 @@
 package types
 
 import (
+	"time"
+
 	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
 )
 
@@ -26,4 +28,44 @@ type AccountBalances struct {
 	Address  string            `json:"address"`
 	Balances []wbtypes.Balance `json:"balances"`
 	Error    *string           `json:"error,omitempty"`
+}
+
+// PaginationDirection selects forward (next) or backward (prev) traversal of
+// a cursor-paginated upstream resource.
+type PaginationDirection string
+
+const (
+	PaginationDirectionNext PaginationDirection = "next"
+	PaginationDirectionPrev PaginationDirection = "prev"
+)
+
+// AccountHistoryParams carries pagination and time-range filters for the
+// account-scoped history endpoints (transactions / operations / state-changes).
+// Cursor is opaque (forwarded verbatim to wallet-backend). All time pointers
+// are nil when the caller omits the corresponding query param.
+type AccountHistoryParams struct {
+	Limit     int32
+	Cursor    *string
+	Direction PaginationDirection
+	Since     *time.Time
+	Until     *time.Time
+}
+
+// PaginationInfo is the cursor-pagination metadata returned alongside a page
+// of items. NextCursor / PrevCursor are nil when HasNext / HasPrevious is
+// false respectively.
+type PaginationInfo struct {
+	NextCursor  *string `json:"next_cursor"`
+	PrevCursor  *string `json:"prev_cursor"`
+	HasNext     bool    `json:"has_next"`
+	HasPrevious bool    `json:"has_previous"`
+}
+
+// PaginatedResponse is the generic response envelope for cursor-paginated
+// list endpoints. Data is always a non-nil slice (empty when no items).
+// This envelope is written directly as the response body — it is NOT wrapped
+// by handlers.HttpResponse, because doing so would nest data twice.
+type PaginatedResponse[T any] struct {
+	Data       []T            `json:"data"`
+	Pagination PaginationInfo `json:"pagination"`
 }

--- a/internal/utils/mocks.go
+++ b/internal/utils/mocks.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 
+	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
+
 	"github.com/stellar/freighter-backend-v2/internal/types"
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
@@ -108,6 +110,40 @@ func (m *MockRPCService) GetLedgerEntries(ctx context.Context, keys []string, ne
 type MockWalletBackendService struct {
 	GetBalancesOverride interface{}
 	GetBalancesError    error
+
+	// Result/Error are the default response when Func is nil. When Func is
+	// set it takes precedence and the test owns the entire response shape —
+	// useful for asserting that parsed query params were forwarded correctly.
+
+	// GetAccountTransactionsResult is returned by GetAccountTransactions when
+	// GetAccountTransactionsFunc is nil and GetAccountTransactionsError is nil.
+	GetAccountTransactionsResult *types.PaginatedResponse[*wbtypes.GraphQLTransaction]
+	// GetAccountTransactionsError is returned by GetAccountTransactions when
+	// GetAccountTransactionsFunc is nil.
+	GetAccountTransactionsError error
+	// GetAccountTransactionsFunc overrides Result/Error when set; the test
+	// controls the full response and can capture/assert call arguments.
+	GetAccountTransactionsFunc func(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.GraphQLTransaction], error)
+
+	// GetAccountOperationsResult is returned by GetAccountOperations when
+	// GetAccountOperationsFunc is nil and GetAccountOperationsError is nil.
+	GetAccountOperationsResult *types.PaginatedResponse[*wbtypes.Operation]
+	// GetAccountOperationsError is returned by GetAccountOperations when
+	// GetAccountOperationsFunc is nil.
+	GetAccountOperationsError error
+	// GetAccountOperationsFunc overrides Result/Error when set; the test
+	// controls the full response and can capture/assert call arguments.
+	GetAccountOperationsFunc func(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.Operation], error)
+
+	// GetAccountStateChangesResult is returned by GetAccountStateChanges when
+	// GetAccountStateChangesFunc is nil and GetAccountStateChangesError is nil.
+	GetAccountStateChangesResult *types.PaginatedResponse[wbtypes.StateChangeNode]
+	// GetAccountStateChangesError is returned by GetAccountStateChanges when
+	// GetAccountStateChangesFunc is nil.
+	GetAccountStateChangesError error
+	// GetAccountStateChangesFunc overrides Result/Error when set; the test
+	// controls the full response and can capture/assert call arguments.
+	GetAccountStateChangesFunc func(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[wbtypes.StateChangeNode], error)
 }
 
 func (m *MockWalletBackendService) Name() string {
@@ -128,4 +164,43 @@ func (m *MockWalletBackendService) GetBalancesByAccountAddresses(ctx context.Con
 	}
 
 	return nil, nil
+}
+
+// GetAccountTransactions returns a stubbed paginated transaction list. If
+// GetAccountTransactionsFunc is set it takes precedence; otherwise
+// GetAccountTransactionsError or GetAccountTransactionsResult is used.
+func (m *MockWalletBackendService) GetAccountTransactions(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.GraphQLTransaction], error) {
+	if m.GetAccountTransactionsFunc != nil {
+		return m.GetAccountTransactionsFunc(ctx, address, network, params)
+	}
+	if m.GetAccountTransactionsError != nil {
+		return nil, m.GetAccountTransactionsError
+	}
+	return m.GetAccountTransactionsResult, nil
+}
+
+// GetAccountOperations returns a stubbed paginated operations list. If
+// GetAccountOperationsFunc is set it takes precedence; otherwise
+// GetAccountOperationsError or GetAccountOperationsResult is used.
+func (m *MockWalletBackendService) GetAccountOperations(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.Operation], error) {
+	if m.GetAccountOperationsFunc != nil {
+		return m.GetAccountOperationsFunc(ctx, address, network, params)
+	}
+	if m.GetAccountOperationsError != nil {
+		return nil, m.GetAccountOperationsError
+	}
+	return m.GetAccountOperationsResult, nil
+}
+
+// GetAccountStateChanges returns a stubbed paginated state-changes list. If
+// GetAccountStateChangesFunc is set it takes precedence; otherwise
+// GetAccountStateChangesError or GetAccountStateChangesResult is used.
+func (m *MockWalletBackendService) GetAccountStateChanges(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[wbtypes.StateChangeNode], error) {
+	if m.GetAccountStateChangesFunc != nil {
+		return m.GetAccountStateChangesFunc(ctx, address, network, params)
+	}
+	if m.GetAccountStateChangesError != nil {
+		return nil, m.GetAccountStateChangesError
+	}
+	return m.GetAccountStateChangesResult, nil
 }

--- a/internal/utils/mocks.go
+++ b/internal/utils/mocks.go
@@ -3,8 +3,6 @@ package utils
 import (
 	"context"
 
-	wbtypes "github.com/stellar/wallet-backend/pkg/wbclient/types"
-
 	"github.com/stellar/freighter-backend-v2/internal/types"
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
@@ -117,33 +115,11 @@ type MockWalletBackendService struct {
 
 	// GetAccountTransactionsResult is returned by GetAccountTransactions when
 	// GetAccountTransactionsFunc is nil and GetAccountTransactionsError is nil.
-	GetAccountTransactionsResult *types.PaginatedResponse[*wbtypes.GraphQLTransaction]
-	// GetAccountTransactionsError is returned by GetAccountTransactions when
-	// GetAccountTransactionsFunc is nil.
+	GetAccountTransactionsResult *types.PaginatedResponse[*types.AccountTransaction]
+	// GetAccountTransactionsError is returned when GetAccountTransactionsFunc is nil.
 	GetAccountTransactionsError error
-	// GetAccountTransactionsFunc overrides Result/Error when set; the test
-	// controls the full response and can capture/assert call arguments.
-	GetAccountTransactionsFunc func(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.GraphQLTransaction], error)
-
-	// GetAccountOperationsResult is returned by GetAccountOperations when
-	// GetAccountOperationsFunc is nil and GetAccountOperationsError is nil.
-	GetAccountOperationsResult *types.PaginatedResponse[*wbtypes.Operation]
-	// GetAccountOperationsError is returned by GetAccountOperations when
-	// GetAccountOperationsFunc is nil.
-	GetAccountOperationsError error
-	// GetAccountOperationsFunc overrides Result/Error when set; the test
-	// controls the full response and can capture/assert call arguments.
-	GetAccountOperationsFunc func(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.Operation], error)
-
-	// GetAccountStateChangesResult is returned by GetAccountStateChanges when
-	// GetAccountStateChangesFunc is nil and GetAccountStateChangesError is nil.
-	GetAccountStateChangesResult *types.PaginatedResponse[wbtypes.StateChangeNode]
-	// GetAccountStateChangesError is returned by GetAccountStateChanges when
-	// GetAccountStateChangesFunc is nil.
-	GetAccountStateChangesError error
-	// GetAccountStateChangesFunc overrides Result/Error when set; the test
-	// controls the full response and can capture/assert call arguments.
-	GetAccountStateChangesFunc func(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[wbtypes.StateChangeNode], error)
+	// GetAccountTransactionsFunc overrides Result/Error when set.
+	GetAccountTransactionsFunc func(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*types.AccountTransaction], error)
 }
 
 func (m *MockWalletBackendService) Name() string {
@@ -166,10 +142,8 @@ func (m *MockWalletBackendService) GetBalancesByAccountAddresses(ctx context.Con
 	return nil, nil
 }
 
-// GetAccountTransactions returns a stubbed paginated transaction list. If
-// GetAccountTransactionsFunc is set it takes precedence; otherwise
-// GetAccountTransactionsError or GetAccountTransactionsResult is used.
-func (m *MockWalletBackendService) GetAccountTransactions(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.GraphQLTransaction], error) {
+// GetAccountTransactions returns a stubbed paginated transaction list.
+func (m *MockWalletBackendService) GetAccountTransactions(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*types.AccountTransaction], error) {
 	if m.GetAccountTransactionsFunc != nil {
 		return m.GetAccountTransactionsFunc(ctx, address, network, params)
 	}
@@ -177,30 +151,4 @@ func (m *MockWalletBackendService) GetAccountTransactions(ctx context.Context, a
 		return nil, m.GetAccountTransactionsError
 	}
 	return m.GetAccountTransactionsResult, nil
-}
-
-// GetAccountOperations returns a stubbed paginated operations list. If
-// GetAccountOperationsFunc is set it takes precedence; otherwise
-// GetAccountOperationsError or GetAccountOperationsResult is used.
-func (m *MockWalletBackendService) GetAccountOperations(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[*wbtypes.Operation], error) {
-	if m.GetAccountOperationsFunc != nil {
-		return m.GetAccountOperationsFunc(ctx, address, network, params)
-	}
-	if m.GetAccountOperationsError != nil {
-		return nil, m.GetAccountOperationsError
-	}
-	return m.GetAccountOperationsResult, nil
-}
-
-// GetAccountStateChanges returns a stubbed paginated state-changes list. If
-// GetAccountStateChangesFunc is set it takes precedence; otherwise
-// GetAccountStateChangesError or GetAccountStateChangesResult is used.
-func (m *MockWalletBackendService) GetAccountStateChanges(ctx context.Context, address, network string, params types.AccountHistoryParams) (*types.PaginatedResponse[wbtypes.StateChangeNode], error) {
-	if m.GetAccountStateChangesFunc != nil {
-		return m.GetAccountStateChangesFunc(ctx, address, network, params)
-	}
-	if m.GetAccountStateChangesError != nil {
-		return nil, m.GetAccountStateChangesError
-	}
-	return m.GetAccountStateChangesResult, nil
 }


### PR DESCRIPTION
Closes #101 

## Summary

Collapses the three account-history endpoints into a single call:

- **`GET /api/v1/accounts/{address}/transactions`** — paginated transactions, each embedding the calling account's `operations` and `state_changes`.

Backed by the new wallet-backend SDK method `GetAccountTransactionsWithOpsAndStateChanges` (one nested GraphQL call — ~3 batched DB queries per page, not N+1). The response is fully **snake_case** with **narrow-polymorphic** state changes (discriminated by `type`) and 64-bit `id`/`fee_charged` encoded as JSON **strings** for JS-client precision.


## Changes
- `internal/types/account_history.go` — snake_case response types: `AccountTransaction` (embeds base `Transaction`), `Operation`, and the `StateChange` interface + 9 variants.
- `internal/services/account_history_mapping.go` — pure wbclient→snake_case mappers (incl. the 9-way state-change switch).
- `internal/services/wallet_backend.go` — `GetAccountTransactions` rewritten to the single nested call; the two flat service methods + empty-page helpers removed.
- `internal/types/interfaces.go`, `internal/utils/mocks.go`, `internal/api/handlers/account_history.go`, `internal/api/serve.go` — trimmed to the one method / one route.
- `cmd/serve/serve.go` — `account-history-max-limit` capped at 100 (the upstream page-size ceiling), failing fast at startup instead of 502-ing per request.