### PR TITLE
fix(metrics): bound network and method label cardinality 

### DIFF
--- a/internal/api/handlers/rpc_health.go
+++ b/internal/api/handlers/rpc_health.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
@@ -31,6 +33,17 @@ func (h *RPCHealthHandler) CheckRPCHealth(w http.ResponseWriter, r *http.Request
 	network := r.URL.Query().Get("network")
 	if network == "" {
 		network = types.PUBLIC
+	}
+
+	// Validate against the finite set of supported networks before passing the
+	// value downstream. The value flows into Prometheus metric labels, so an
+	// unbounded, caller-controlled network would create unbounded label
+	// cardinality and unbounded memory growth.
+	if !isValidNetwork(network) {
+		return httperror.BadRequest(
+			fmt.Sprintf("invalid network: network must be %s, %s or %s", types.PUBLIC, types.TESTNET, types.FUTURENET),
+			errors.New("invalid network"),
+		)
 	}
 
 	// Get RPC health status

--- a/internal/api/handlers/rpc_health_test.go
+++ b/internal/api/handlers/rpc_health_test.go
@@ -86,6 +86,29 @@ func TestRPCHealthHandler_CheckRPCHealth(t *testing.T) {
 		assert.Equal(t, types.PUBLIC, capturedNetwork)
 	})
 
+	t.Run("should reject an invalid network without calling the RPC service", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		mockRPC := &utils.MockRPCService{
+			GetHealthFunc: func(network string) (types.GetHealthResponse, error) {
+				called = true
+				return types.GetHealthResponse{Status: types.StatusHealthy}, nil
+			},
+		}
+		handler := NewRPCHealthHandler(mockRPC)
+
+		req, err := http.NewRequest("GET", "/rpc-health?network=ATTACK_0001", nil)
+		require.NoError(t, err)
+		rr := httptest.NewRecorder()
+
+		err = handler.CheckRPCHealth(rr, req)
+		require.Error(t, err)
+		httpErr, ok := err.(*httperror.HttpError)
+		require.True(t, ok, "error should be an HttpError")
+		assert.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+		assert.False(t, called, "RPC service must not be called for an invalid network")
+	})
+
 	t.Run("should return unhealthy status on RPC service failure", func(t *testing.T) {
 		t.Parallel()
 		mockRPC := &utils.MockRPCService{

--- a/internal/api/middleware/metrics.go
+++ b/internal/api/middleware/metrics.go
@@ -10,6 +10,24 @@ import (
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
 )
 
+// sanitizeMethod buckets any non-standard HTTP method into a single "other"
+// label. Go's HTTP server accepts arbitrary method tokens from the client, and
+// the method flows into Prometheus metric vectors (which retain a time series
+// per unique label value). Without bucketing, a caller could send unique
+// method tokens — especially against unmatched routes, where the handler label
+// collapses to "unknown" — and grow label cardinality (and memory) without
+// bound.
+func sanitizeMethod(method string) string {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return method
+	default:
+		return "other"
+	}
+}
+
 // Metrics returns middleware that records HTTP metrics using BufferedResponseWriter.
 func Metrics(h *metrics.HTTP) Middleware {
 	return func(next http.Handler) http.Handler {
@@ -31,7 +49,7 @@ func Metrics(h *metrics.HTTP) Middleware {
 				handler = "unknown"
 			}
 
-			labels := []string{handler, r.Method, strconv.Itoa(code)}
+			labels := []string{handler, sanitizeMethod(r.Method), strconv.Itoa(code)}
 			h.RequestsTotal.WithLabelValues(labels...).Inc()
 			h.RequestDuration.WithLabelValues(labels...).Observe(time.Since(start).Seconds())
 		})

--- a/internal/api/middleware/metrics_test.go
+++ b/internal/api/middleware/metrics_test.go
@@ -155,6 +155,35 @@ func TestMetricsMiddleware_ErrorStatusCode(t *testing.T) {
 	assert.Equal(t, float64(1), count)
 }
 
+func TestMetricsMiddleware_BucketsNonStandardMethod(t *testing.T) {
+	h, reg := newTestHTTPMetrics(t)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	mw := Metrics(h)(inner)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bw := NewBufferedResponseWriter(w)
+		mw.ServeHTTP(bw, r)
+	})
+
+	// Send several unique, non-standard method tokens against an unmatched
+	// route. Each must collapse to the single "other" bucket so an attacker
+	// cannot grow label cardinality without bound.
+	for _, method := range []string{"ATTACK1", "ATTACK2", "ATTACK3"} {
+		req := httptest.NewRequest(method, "/nonexistent", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+	}
+
+	// Exactly one series exists, under the "other" bucket, with all 3 requests.
+	count := testutil.ToFloat64(h.RequestsTotal.WithLabelValues("unknown", "other", "404"))
+	assert.Equal(t, float64(3), count)
+	assert.Equal(t, 1, testutil.CollectAndCount(reg, "freighter_http_requests_total"))
+}
+
 func TestMetricsMiddleware_MultipleRequests(t *testing.T) {
 	h, _ := newTestHTTPMetrics(t)
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -11,7 +11,25 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/stellar/freighter-backend-v2/internal/types"
 )
+
+// sanitizeNetwork buckets any value that is not one of the finite, supported
+// networks into a single "unknown" label. The network label flows into
+// Prometheus metric vectors, which retain a time series per unique label value
+// for the lifetime of the process. Bucketing here caps the cardinality of the
+// network label so a caller-controlled value can never cause unbounded series
+// (and thus unbounded memory) growth, independent of any handler-level
+// validation.
+func sanitizeNetwork(network string) string {
+	switch network {
+	case types.PUBLIC, types.TESTNET, types.FUTURENET:
+		return network
+	default:
+		return "unknown"
+	}
+}
 
 // UpstreamError represents an error from an upstream service that should be
 // classified with a specific kind and optional error code for metric labels.
@@ -115,6 +133,7 @@ func Record(m *Service, service, method, network string, duration float64, err e
 	if m == nil {
 		return
 	}
+	network = sanitizeNetwork(network)
 	m.CallsTotal.WithLabelValues(service, method, network).Inc()
 	m.CallDuration.WithLabelValues(service, method, network).Observe(duration)
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes an unauthenticated availability vector in freighter-backend-v2.

`GET /api/v1/rpc-health` read an arbitrary `network` query parameter and forwarded it unchanged into Prometheus service-metric labels. Prometheus vectors keep one time series per unique label value for the life of the process — so an attacker could send requests with unique `network` values to grow memory without bound and OOM-kill the service.

This was reproduced in a 32 MiB container: exit `137`, `oom=true`.

The root cause is that `rpc-health` skipped the finite-network validation every other handler already applies. The fix validates at the handler, then adds defense-in-depth at the metrics layer so no caller-controlled value can expand label cardinality without bound.

While auditing the rest of the API for the same bug class, I found a second, lower-severity vector: the HTTP metrics middleware records the raw client-sent `method` token on every request (including unmatched 404s), and Go's server accepts arbitrary method tokens. That label is now bucketed too.

## What's in this PR

- `internal/api/handlers/rpc_health.go` — validate `network` against `{PUBLIC, TESTNET, FUTURENET}` before calling `GetHealth`; invalid values return `400` and never reach the metrics layer.
- `internal/metrics/metrics.go` — `sanitizeNetwork()` buckets any non-standard network to `"unknown"` inside `Record()`, capping the `network` label regardless of caller.
- `internal/api/middleware/metrics.go` — `sanitizeMethod()` buckets non-standard HTTP methods to `"other"`, closing the `method`-label vector on unmatched routes.
- `internal/api/handlers/rpc_health_test.go` — asserts an invalid network is rejected and the RPC service is never called.
- `internal/api/middleware/metrics_test.go` — asserts unique non-standard method tokens collapse to a single series.

## Audit notes

The only two places caller input reaches a Prometheus label are `metrics.Record` and the HTTP middleware. Both are now bounded:

- `service` / `method` (service metrics) are hardcoded constants.
- `error_type` comes from `ClassifyError` — a fixed set of kinds plus integer RPC/HTTP codes.
- `handler` is `r.Pattern` (registered route pattern, falls back to `"unknown"`); `code` is a status int.

## Test plan

- [x] `go test ./internal/...` green locally
- [x] `gofmt` clean, `go vet ./...` clean
- [ ] CI green (`build`, `check`, `Analyze (go)` currently pending)