### PR TITLE
fix(rpc-health): restore isValidNetwork dropped by #100 (fixes main build)

### DIFF
--- a/internal/api/handlers/utils.go
+++ b/internal/api/handlers/utils.go
@@ -33,10 +33,9 @@ func isValidWalletBackendNetwork(network string) bool {
 // health check supports (pubnet, testnet, futurenet). Used by rpc-health to
 // reject caller-controlled networks before they reach a Prometheus label.
 //
-// NOTE: this restores a helper that #109 (metric-cardinality DoS guard) relies
-// on but #100 (account-history) removed when it renamed the validator to the
-// wallet-backend-specific variant above, leaving rpc_health.go's call site
-// dangling — i.e. main currently does not compile. See the PR discussion.
+// NOTE: This validator is intentionally distinct from isValidWalletBackendNetwork:
+// rpc-health supports FUTURENET, but the wallet-backend client is only configured
+// for PUBLIC and TESTNET.
 func isValidNetwork(network string) bool {
 	return network == types.PUBLIC || network == types.TESTNET || network == types.FUTURENET
 }

--- a/internal/api/handlers/utils.go
+++ b/internal/api/handlers/utils.go
@@ -29,6 +29,18 @@ func isValidWalletBackendNetwork(network string) bool {
 	return network == types.PUBLIC || network == types.TESTNET
 }
 
+// isValidNetwork reports whether network is one of the Stellar networks the RPC
+// health check supports (pubnet, testnet, futurenet). Used by rpc-health to
+// reject caller-controlled networks before they reach a Prometheus label.
+//
+// NOTE: this restores a helper that #109 (metric-cardinality DoS guard) relies
+// on but #100 (account-history) removed when it renamed the validator to the
+// wallet-backend-specific variant above, leaving rpc_health.go's call site
+// dangling — i.e. main currently does not compile. See the PR discussion.
+func isValidNetwork(network string) bool {
+	return network == types.PUBLIC || network == types.TESTNET || network == types.FUTURENET
+}
+
 // translateServiceError maps a service-layer error to a typed HttpError per
 // the spec's REST-honest mapping. Logs all non-404 errors with context;
 // account-not-found is a normal client outcome and is not logged.


### PR DESCRIPTION
## TL;DR

`main` currently does not compile: the RPC health-check handler calls a network-validation helper that was accidentally removed, so the build fails for everyone (every open PR is red). This restores that helper. One-line fix, no behavior change to anything that already worked.

Urgent — this unblocks all in-flight branches. Please review/merge ahead of feature work.

<details>
<summary>Implementation details (for agents)</summary>

**Root cause:** Two PRs collided across merge order:
- **#109** (bound network/method label cardinality to prevent OOM DoS) added an [`isValidNetwork(network)` guard](https://github.com/stellar/freighter-backend-v2/blob/f61609d5899d4f54fe99ae83cc9b1a63af7e59f6/internal/api/handlers/rpc_health.go#L42-L42) in `rpc_health.go` so a caller-controlled `network` query param can't create unbounded Prometheus label cardinality.
- **#100** (account-history), merged *after* #109, renamed that validator to `isValidWalletBackendNetwork` (pubnet/testnet only) and **removed `isValidNetwork`** — without updating #109's call site. The result references an undefined symbol:
  ```
  internal/api/handlers/rpc_health.go:42:6: undefined: isValidNetwork
  ```
  Confirmed against a clean checkout of `origin/main` (not specific to any feature branch).

**Fix:** re-add [`isValidNetwork`](https://github.com/stellar/freighter-backend-v2/blob/f61609d5899d4f54fe99ae83cc9b1a63af7e59f6/internal/api/handlers/utils.go#L40-L43) as the **RPC-supported-network** validator (pubnet, testnet, **futurenet**). This is intentionally distinct from `isValidWalletBackendNetwork`, which excludes futurenet because the wallet-backend client has no futurenet config — rpc-health, by contrast, supports all three (its error message and the "reject an invalid network" test expect that). Pointing rpc-health at the wallet-backend validator instead would wrongly reject futurenet, so the two validators must coexist.

**Verification:** `go build ./...`, `gofmt -l`, `go vet ./...`, and `go test ./internal/api/handlers/...` all pass on `main` + this commit. No test changes were needed — `rpc_health_test.go`'s invalid-network case and `utils_test.go`'s `isValidWalletBackendNetwork` test both pass as-is.

**Follow-ups:** worth a quick look at whether CI's required checks should block merge when the base branch doesn't compile (this slipped in because #100 and #109 were green independently but conflicted semantically at merge).

</details>
