### PR TITLE
fix(prices): return null for any zero price instead of "0"

### DIFF
--- a/internal/services/prices.go
+++ b/internal/services/prices.go
@@ -291,11 +291,12 @@ func (p *pricesService) fetchFromUpstream(ctx context.Context, network, cacheNet
 		return nil, false
 	}
 
-	// A known asset can return 200 with no `price` field (illiquid, no recent
-	// trades). That is unpriceable, not a price of 0: honor the documented
-	// null contract rather than leaking a zero value. Resolves to (nil, true)
-	// like not-found/malformed so it caches as an authoritative miss.
-	if asset.Price == nil {
+	// A zero price — whether Stellar Expert omitted the `price` field (a known
+	// but illiquid asset; JSON absence decodes to 0) or reported a genuine 0 —
+	// is unpriceable. Honor the documented null contract rather than leaking a
+	// "0" string. Resolves to (nil, true) like not-found/malformed so it caches
+	// as an authoritative miss.
+	if asset.Price == 0 {
 		return nil, true
 	}
 
@@ -310,11 +311,11 @@ func (p *pricesService) fetchFromUpstream(ctx context.Context, network, cacheNet
 			logger.Warn("prices: candles fetch failed; 24h change unavailable", "asset", stellarExpertID, "error", candlesErr)
 		}
 	} else {
-		change24h = change24hFromCandles(*asset.Price, candles, to)
+		change24h = change24hFromCandles(asset.Price, candles, to)
 	}
 
 	entry := &types.PriceEntry{
-		CurrentPrice:             formatPrice(*asset.Price),
+		CurrentPrice:             formatPrice(asset.Price),
 		PercentagePriceChange24h: change24h,
 	}
 	p.cachePositive(ctx, cacheNet, canonical, entry)

--- a/internal/services/prices.go
+++ b/internal/services/prices.go
@@ -291,6 +291,14 @@ func (p *pricesService) fetchFromUpstream(ctx context.Context, network, cacheNet
 		return nil, false
 	}
 
+	// A known asset can return 200 with no `price` field (illiquid, no recent
+	// trades). That is unpriceable, not a price of 0: honor the documented
+	// null contract rather than leaking a zero value. Resolves to (nil, true)
+	// like not-found/malformed so it caches as an authoritative miss.
+	if asset.Price == nil {
+		return nil, true
+	}
+
 	// The 24h change comes only from the hourly candles window, which can pin
 	// a true trailing 24h (±1h). When candles are unavailable or can't cover
 	// ~24h we return null rather than a mislabeled day-over-day delta from the
@@ -302,11 +310,11 @@ func (p *pricesService) fetchFromUpstream(ctx context.Context, network, cacheNet
 			logger.Warn("prices: candles fetch failed; 24h change unavailable", "asset", stellarExpertID, "error", candlesErr)
 		}
 	} else {
-		change24h = change24hFromCandles(asset.Price, candles, to)
+		change24h = change24hFromCandles(*asset.Price, candles, to)
 	}
 
 	entry := &types.PriceEntry{
-		CurrentPrice:             formatPrice(asset.Price),
+		CurrentPrice:             formatPrice(*asset.Price),
 		PercentagePriceChange24h: change24h,
 	}
 	p.cachePositive(ctx, cacheNet, canonical, entry)

--- a/internal/services/prices_test.go
+++ b/internal/services/prices_test.go
@@ -167,15 +167,17 @@ func (f *fakeStellarExpert) CandleCallCount(assetID string) int {
 	return f.candleCalls[assetID]
 }
 
+func floatPtr(v float64) *float64 { return &v }
+
 func TestPrices_HappyPath_NoCache(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().UTC()
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
 	// oldest open=0.158 → (0.16-0.158)/0.158*100 ≈ 1.27
 	stellarExpert.SetCandles("XLM", hourlyCandlesAged(now, 24*time.Hour, 0.158, 0.159))
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.0})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.0)})
 	// flat → 0%
 	stellarExpert.SetCandles("USDC-"+testIssuer+"-1", hourlyCandlesAged(now, 24*time.Hour, 1.0, 1.0))
 
@@ -202,7 +204,7 @@ func TestPrices_UsesCandlesWhenAvailable(t *testing.T) {
 
 	now := time.Now().UTC()
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.10})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.10)})
 	// oldest open=1.222 → (1.10-1.222)/1.222*100 ≈ -9.98 → -9.98
 	stellarExpert.SetCandles("USDC-"+testIssuer+"-1", hourlyCandlesAged(now, 24*time.Hour, 1.222, 1.21))
 
@@ -225,7 +227,7 @@ func TestPrices_CandlesEmpty_NoChange(t *testing.T) {
 
 	stellarExpert := newFakeStellarExpert()
 	// Candles unset on the fake → returns empty.
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.10})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.10)})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	got, err := svc.GetPrices(context.Background(), []string{"USDC:" + testIssuer}, types.PUBLIC)
@@ -243,7 +245,7 @@ func TestPrices_XLM_UsesCandles(t *testing.T) {
 
 	now := time.Now().UTC()
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
 	// oldest open=0.1633 → (0.16 - 0.1633) / 0.1633 * 100 ≈ -2.02
 	stellarExpert.SetCandles("XLM", hourlyCandlesAged(now, 24*time.Hour, 0.1633, 0.1625))
 
@@ -265,7 +267,7 @@ func TestPrices_CandlesError_NoChange(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.0})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.0)})
 	stellarExpert.SetCandleErr("USDC-"+testIssuer+"-1", errors.New("transient candles boom"))
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
@@ -286,7 +288,7 @@ func TestPrices_SparseCandles_NoChange(t *testing.T) {
 
 	now := time.Now().UTC()
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.0})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.0)})
 	// Only 6h of coverage — outside [23h, 25h] from `to`.
 	stellarExpert.SetCandles("USDC-"+testIssuer+"-1", hourlyCandlesAged(now, 6*time.Hour, 0.5, 0.6))
 
@@ -304,7 +306,7 @@ func TestPrices_NotFound_ReturnsNull(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	got, err := svc.GetPrices(context.Background(), []string{"XLM", "BOGUS:" + testIssuer}, types.PUBLIC)
@@ -327,6 +329,39 @@ func TestPrices_Malformed_ReturnsNull(t *testing.T) {
 	assert.Nil(t, got["BAD:"+testIssuer])
 }
 
+// A known asset that Stellar Expert returns with no `price` field (illiquid,
+// no recent trades) is unpriceable and must serialize as null, not a
+// manufactured "0" from the Go zero value.
+func TestPrices_KnownButUnpriced_ReturnsNull(t *testing.T) {
+	t.Parallel()
+
+	stellarExpert := newFakeStellarExpert()
+	stellarExpert.Set("USDyc-"+testIssuer+"-1", &types.StellarExpertAsset{Price: nil})
+
+	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
+	got, err := svc.GetPrices(context.Background(), []string{"USDyc:" + testIssuer}, types.PUBLIC)
+	require.NoError(t, err)
+	entry, ok := got["USDyc:"+testIssuer]
+	assert.True(t, ok)
+	assert.Nil(t, entry, "asset present with no price → null, not \"0\"")
+}
+
+// A genuine upstream price of 0 is a real (documented) value and must be
+// preserved as "0", distinct from the absent-price null case above.
+func TestPrices_GenuineZeroPrice_ReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	stellarExpert := newFakeStellarExpert()
+	stellarExpert.Set("ZERO-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(0)})
+
+	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
+	got, err := svc.GetPrices(context.Background(), []string{"ZERO:" + testIssuer}, types.PUBLIC)
+	require.NoError(t, err)
+	entry := got["ZERO:"+testIssuer]
+	require.NotNil(t, entry, "present price of 0 is a real value, not unpriceable")
+	assert.Equal(t, "0", entry.CurrentPrice)
+}
+
 func TestPrices_UpstreamError_ReturnsNull(t *testing.T) {
 	t.Parallel()
 
@@ -345,7 +380,7 @@ func TestPrices_DedupesDuplicateTokens(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	_, err := svc.GetPrices(context.Background(), []string{"XLM", "XLM", "XLM"}, types.PUBLIC)
@@ -372,7 +407,7 @@ func TestPrices_ConcurrencyCapHonored(t *testing.T) {
 		// Use distinct codes (4 chars) so each canonical id is unique.
 		code := []byte{'A', 'A', 'A', byte('A' + i)}
 		stellarExpertID := string(code) + "-" + testIssuer + "-1"
-		stellarExpert.Set(stellarExpertID, &types.StellarExpertAsset{Price: 1.0})
+		stellarExpert.Set(stellarExpertID, &types.StellarExpertAsset{Price: floatPtr(1.0)})
 		tokens[i] = string(code) + ":" + testIssuer
 	}
 
@@ -394,7 +429,7 @@ func TestPrices_CoalescesConcurrentFetches(t *testing.T) {
 	// A delay wide enough that all goroutines are in-flight at DoChan before
 	// the shared fetch completes, so singleflight coalesces them.
 	stellarExpert.delay = 50 * time.Millisecond
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 
@@ -447,7 +482,7 @@ func TestPrices_PreservesPartialOnContextCancel(t *testing.T) {
 
 	stellarExpert := newFakeStellarExpert()
 	stellarExpert.delay = 100 * time.Millisecond
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
@@ -492,8 +527,8 @@ func TestPrices_CacheOutcomes_NilRedisCountsAllAsMisses(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.0})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.0)})
 
 	reg := prometheus.NewRegistry()
 	pm := metrics.NewPrices(reg)
@@ -534,7 +569,7 @@ func TestPrices_RedisErrors_MGetUnreachable_Increments(t *testing.T) {
 
 	redisStore := store.NewRedisStore("localhost", 1, "") // port 1 = no listener
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
 
 	reg := prometheus.NewRegistry()
 	pm := metrics.NewPrices(reg)
@@ -552,7 +587,7 @@ func TestPrices_NilMetrics_NoOps(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	_, err := svc.GetPrices(context.Background(), []string{"XLM"}, types.PUBLIC)

--- a/internal/services/prices_test.go
+++ b/internal/services/prices_test.go
@@ -167,17 +167,15 @@ func (f *fakeStellarExpert) CandleCallCount(assetID string) int {
 	return f.candleCalls[assetID]
 }
 
-func floatPtr(v float64) *float64 { return &v }
-
 func TestPrices_HappyPath_NoCache(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().UTC()
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
 	// oldest open=0.158 → (0.16-0.158)/0.158*100 ≈ 1.27
 	stellarExpert.SetCandles("XLM", hourlyCandlesAged(now, 24*time.Hour, 0.158, 0.159))
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.0)})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.0})
 	// flat → 0%
 	stellarExpert.SetCandles("USDC-"+testIssuer+"-1", hourlyCandlesAged(now, 24*time.Hour, 1.0, 1.0))
 
@@ -204,7 +202,7 @@ func TestPrices_UsesCandlesWhenAvailable(t *testing.T) {
 
 	now := time.Now().UTC()
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.10)})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.10})
 	// oldest open=1.222 → (1.10-1.222)/1.222*100 ≈ -9.98 → -9.98
 	stellarExpert.SetCandles("USDC-"+testIssuer+"-1", hourlyCandlesAged(now, 24*time.Hour, 1.222, 1.21))
 
@@ -227,7 +225,7 @@ func TestPrices_CandlesEmpty_NoChange(t *testing.T) {
 
 	stellarExpert := newFakeStellarExpert()
 	// Candles unset on the fake → returns empty.
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.10)})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.10})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	got, err := svc.GetPrices(context.Background(), []string{"USDC:" + testIssuer}, types.PUBLIC)
@@ -245,7 +243,7 @@ func TestPrices_XLM_UsesCandles(t *testing.T) {
 
 	now := time.Now().UTC()
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
 	// oldest open=0.1633 → (0.16 - 0.1633) / 0.1633 * 100 ≈ -2.02
 	stellarExpert.SetCandles("XLM", hourlyCandlesAged(now, 24*time.Hour, 0.1633, 0.1625))
 
@@ -267,7 +265,7 @@ func TestPrices_CandlesError_NoChange(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.0)})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.0})
 	stellarExpert.SetCandleErr("USDC-"+testIssuer+"-1", errors.New("transient candles boom"))
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
@@ -288,7 +286,7 @@ func TestPrices_SparseCandles_NoChange(t *testing.T) {
 
 	now := time.Now().UTC()
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.0)})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.0})
 	// Only 6h of coverage — outside [23h, 25h] from `to`.
 	stellarExpert.SetCandles("USDC-"+testIssuer+"-1", hourlyCandlesAged(now, 6*time.Hour, 0.5, 0.6))
 
@@ -306,7 +304,7 @@ func TestPrices_NotFound_ReturnsNull(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	got, err := svc.GetPrices(context.Background(), []string{"XLM", "BOGUS:" + testIssuer}, types.PUBLIC)
@@ -329,37 +327,22 @@ func TestPrices_Malformed_ReturnsNull(t *testing.T) {
 	assert.Nil(t, got["BAD:"+testIssuer])
 }
 
-// A known asset that Stellar Expert returns with no `price` field (illiquid,
-// no recent trades) is unpriceable and must serialize as null, not a
-// manufactured "0" from the Go zero value.
-func TestPrices_KnownButUnpriced_ReturnsNull(t *testing.T) {
+// A zero price is unpriceable and must serialize as null, not a manufactured
+// "0". This covers both Stellar Expert omitting the `price` field for a known
+// but illiquid asset (JSON absence decodes to 0) and a genuine reported 0 —
+// the two are indistinguishable and treated identically.
+func TestPrices_ZeroPrice_ReturnsNull(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("USDyc-"+testIssuer+"-1", &types.StellarExpertAsset{Price: nil})
+	stellarExpert.Set("USDyc-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 0})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	got, err := svc.GetPrices(context.Background(), []string{"USDyc:" + testIssuer}, types.PUBLIC)
 	require.NoError(t, err)
 	entry, ok := got["USDyc:"+testIssuer]
 	assert.True(t, ok)
-	assert.Nil(t, entry, "asset present with no price → null, not \"0\"")
-}
-
-// A genuine upstream price of 0 is a real (documented) value and must be
-// preserved as "0", distinct from the absent-price null case above.
-func TestPrices_GenuineZeroPrice_ReturnsZero(t *testing.T) {
-	t.Parallel()
-
-	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("ZERO-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(0)})
-
-	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
-	got, err := svc.GetPrices(context.Background(), []string{"ZERO:" + testIssuer}, types.PUBLIC)
-	require.NoError(t, err)
-	entry := got["ZERO:"+testIssuer]
-	require.NotNil(t, entry, "present price of 0 is a real value, not unpriceable")
-	assert.Equal(t, "0", entry.CurrentPrice)
+	assert.Nil(t, entry, "zero price → null, not \"0\"")
 }
 
 func TestPrices_UpstreamError_ReturnsNull(t *testing.T) {
@@ -380,7 +363,7 @@ func TestPrices_DedupesDuplicateTokens(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	_, err := svc.GetPrices(context.Background(), []string{"XLM", "XLM", "XLM"}, types.PUBLIC)
@@ -407,7 +390,7 @@ func TestPrices_ConcurrencyCapHonored(t *testing.T) {
 		// Use distinct codes (4 chars) so each canonical id is unique.
 		code := []byte{'A', 'A', 'A', byte('A' + i)}
 		stellarExpertID := string(code) + "-" + testIssuer + "-1"
-		stellarExpert.Set(stellarExpertID, &types.StellarExpertAsset{Price: floatPtr(1.0)})
+		stellarExpert.Set(stellarExpertID, &types.StellarExpertAsset{Price: 1.0})
 		tokens[i] = string(code) + ":" + testIssuer
 	}
 
@@ -429,7 +412,7 @@ func TestPrices_CoalescesConcurrentFetches(t *testing.T) {
 	// A delay wide enough that all goroutines are in-flight at DoChan before
 	// the shared fetch completes, so singleflight coalesces them.
 	stellarExpert.delay = 50 * time.Millisecond
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 
@@ -482,7 +465,7 @@ func TestPrices_PreservesPartialOnContextCancel(t *testing.T) {
 
 	stellarExpert := newFakeStellarExpert()
 	stellarExpert.delay = 100 * time.Millisecond
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
@@ -527,8 +510,8 @@ func TestPrices_CacheOutcomes_NilRedisCountsAllAsMisses(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
-	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: floatPtr(1.0)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
+	stellarExpert.Set("USDC-"+testIssuer+"-1", &types.StellarExpertAsset{Price: 1.0})
 
 	reg := prometheus.NewRegistry()
 	pm := metrics.NewPrices(reg)
@@ -569,7 +552,7 @@ func TestPrices_RedisErrors_MGetUnreachable_Increments(t *testing.T) {
 
 	redisStore := store.NewRedisStore("localhost", 1, "") // port 1 = no listener
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
 
 	reg := prometheus.NewRegistry()
 	pm := metrics.NewPrices(reg)
@@ -587,7 +570,7 @@ func TestPrices_NilMetrics_NoOps(t *testing.T) {
 	t.Parallel()
 
 	stellarExpert := newFakeStellarExpert()
-	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: floatPtr(0.16)})
+	stellarExpert.Set("XLM", &types.StellarExpertAsset{Price: 0.16})
 
 	svc := NewPricesService(stellarExpert, nil, PricesServiceConfig{}, nil, nil)
 	_, err := svc.GetPrices(context.Background(), []string{"XLM"}, types.PUBLIC)

--- a/internal/services/stellar_expert_test.go
+++ b/internal/services/stellar_expert_test.go
@@ -42,7 +42,8 @@ func TestStellarExpert_GetAsset_Success(t *testing.T) {
 	assert.Equal(t, "/explorer/public/asset/XLM", gotPath)
 	assert.Equal(t, "Bearer test-key", gotAuth)
 	assert.Equal(t, "https://stellar.expert", gotOrigin)
-	assert.InDelta(t, 0.15968, asset.Price, 1e-9)
+	require.NotNil(t, asset.Price)
+	assert.InDelta(t, 0.15968, *asset.Price, 1e-9)
 }
 
 func TestStellarExpert_GetAsset_OmitsAuthHeaderWhenKeyEmpty(t *testing.T) {

--- a/internal/services/stellar_expert_test.go
+++ b/internal/services/stellar_expert_test.go
@@ -42,8 +42,7 @@ func TestStellarExpert_GetAsset_Success(t *testing.T) {
 	assert.Equal(t, "/explorer/public/asset/XLM", gotPath)
 	assert.Equal(t, "Bearer test-key", gotAuth)
 	assert.Equal(t, "https://stellar.expert", gotOrigin)
-	require.NotNil(t, asset.Price)
-	assert.InDelta(t, 0.15968, *asset.Price, 1e-9)
+	assert.InDelta(t, 0.15968, asset.Price, 1e-9)
 }
 
 func TestStellarExpert_GetAsset_OmitsAuthHeaderWhenKeyEmpty(t *testing.T) {

--- a/internal/types/interfaces.go
+++ b/internal/types/interfaces.go
@@ -48,11 +48,12 @@ type WalletBackendService interface {
 }
 
 // StellarExpertAsset is the subset of the Stellar Expert /asset/{id} response
-// we care about for pricing. Price is a pointer so an absent `price` field
-// (a known but illiquid/unpriced asset) is distinguishable from a genuine
-// upstream price of 0; nil means unpriceable, not zero.
+// we care about for pricing. A zero Price means unpriceable — either Stellar
+// Expert omitted the `price` field (a known but illiquid asset; JSON absence
+// decodes to 0) or reported a genuine 0. Callers map that to a null price
+// rather than a "0" string.
 type StellarExpertAsset struct {
-	Price *float64 `json:"price"`
+	Price float64 `json:"price"`
 }
 
 // StellarExpertCandle is one row of /asset/{id}/candles.

--- a/internal/types/interfaces.go
+++ b/internal/types/interfaces.go
@@ -48,9 +48,11 @@ type WalletBackendService interface {
 }
 
 // StellarExpertAsset is the subset of the Stellar Expert /asset/{id} response
-// we care about for pricing.
+// we care about for pricing. Price is a pointer so an absent `price` field
+// (a known but illiquid/unpriced asset) is distinguishable from a genuine
+// upstream price of 0; nil means unpriceable, not zero.
 type StellarExpertAsset struct {
-	Price float64 `json:"price"`
+	Price *float64 `json:"price"`
 }
 
 // StellarExpertCandle is one row of /asset/{id}/candles.


### PR DESCRIPTION
## Summary

The `/api/v1/token-prices` endpoint is documented to return `null` for any unpriceable token, but a token that Stellar Expert *knows* yet has no price for (illiquid, no `price` field in the 200 response) came back as `currentPrice: "0"` instead. That "0" is a Go zero-value leak, not a real price — in the extension it reads as a present value, suppresses the `null`-gated spot-price fallback, and shows a misleading $0.00.

Root cause: an absent `price` field decodes to the Go zero value `0`, indistinguishable from a genuine upstream price of 0. Rather than try to tell them apart, this PR treats any zero price as unpriceable — a real 0 is just as unpriceable as an absent one — and honors the documented `null` contract.

## What's in this PR

- `internal/types/interfaces.go` — `StellarExpertAsset.Price` stays a plain `float64`; comment documents that any `0` (absent field or genuine) means unpriceable.
- `internal/services/prices.go` — `fetchFromUpstream` gates on `asset.Price == 0`, resolving to `(nil, true)` so it serializes as `null` and caches as an authoritative miss (same as not-found/malformed).
- `internal/services/prices_test.go` — merges the two zero cases into one `TestPrices_ZeroPrice_ReturnsNull`, drops the `floatPtr` helper, updates fixtures to plain `float64`.
- `internal/services/stellar_expert_test.go` — asserts on the now-value `Price` field.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/services/... ./internal/api/handlers/...` pass
- [x] New case verified: `TestPrices_ZeroPrice_ReturnsNull`
- [x] Confirmed live against Stellar Expert: `USDyc:GDDRGUTO...` returns 200 with `price` absent (fixed → `null`); `WSGBP:GDSVWEA7...` returns a real price
- [ ] CI green
