### PR TITLE
feat(db): add DB_ENABLED to run without a database

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -48,15 +48,20 @@ func (s *ServeCmd) Command() *cobra.Command {
 			if _, err := auth.ParseMode(s.Cfg.AppConfig.AuthMode); err != nil {
 				return fmt.Errorf("--auth-mode: %w", err)
 			}
-			// The database is a hard dependency: fail fast with a clear message
-			// rather than surfacing an opaque connection error deeper in startup.
-			if err := s.Cfg.DatabaseConfig.Validate(); err != nil {
-				return err
-			}
-			// serve sources the pool tuning from flags, so validate them here
-			// (migrate uses package defaults and skips this).
-			if err := s.Cfg.DatabaseConfig.ValidatePoolConfig(); err != nil {
-				return err
+			// The database is validated only when enabled. With --db-enabled=false
+			// the service runs without a database (DB-backed features report
+			// unavailable), so an empty DATABASE_URL must not fail boot.
+			if s.Cfg.DatabaseConfig.Enabled {
+				// Fail fast with a clear message rather than surfacing an opaque
+				// connection error deeper in startup.
+				if err := s.Cfg.DatabaseConfig.Validate(); err != nil {
+					return err
+				}
+				// serve sources the pool tuning from flags, so validate them here
+				// (migrate uses package defaults and skips this).
+				if err := s.Cfg.DatabaseConfig.ValidatePoolConfig(); err != nil {
+					return err
+				}
 			}
 			return nil
 		},
@@ -106,7 +111,8 @@ func (s *ServeCmd) Command() *cobra.Command {
 	cmd.Flags().StringVar(&s.Cfg.RedisConfig.Password, "redis-password", "", "Redis password")
 
 	// Database Config
-	cmd.Flags().StringVar(&s.Cfg.DatabaseConfig.URL, "database-url", "", "PostgreSQL connection string (env DATABASE_URL). Required.")
+	cmd.Flags().BoolVar(&s.Cfg.DatabaseConfig.Enabled, "db-enabled", true, "Enable the database subsystem. Set false (env DB_ENABLED) to run without a database; DATABASE_URL is then not required.")
+	cmd.Flags().StringVar(&s.Cfg.DatabaseConfig.URL, "database-url", "", "PostgreSQL connection string (env DATABASE_URL). Required unless --db-enabled=false.")
 	cmd.Flags().IntVar(&s.Cfg.DatabaseConfig.MaxConns, "db-max-conns", 10, "Maximum number of connections in the DB pool")
 	cmd.Flags().IntVar(&s.Cfg.DatabaseConfig.MinConns, "db-min-conns", 2, "Minimum number of idle connections kept in the DB pool")
 	cmd.Flags().DurationVar(&s.Cfg.DatabaseConfig.MaxConnLifetime, "db-max-conn-lifetime", 5*time.Minute, "Maximum lifetime of a pooled DB connection before it is recycled")

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -105,6 +105,31 @@ func TestServeCmd_RejectsEmptyDatabaseURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "database-url")
 }
 
+func TestServeCmd_DBEnabledDefaultsTrue(t *testing.T) {
+	t.Parallel()
+
+	cmd := (&ServeCmd{Cfg: &config.Config{}}).Command()
+	dbEnabled, err := cmd.Flags().GetBool("db-enabled")
+	require.NoError(t, err)
+	assert.True(t, dbEnabled, "db-enabled should default to true")
+}
+
+func TestServeCmd_AllowsEmptyDatabaseURLWhenDBDisabled(t *testing.T) {
+	// No t.Parallel(): t.Setenv is incompatible with parallel tests. Clear
+	// DATABASE_URL so it can't be bound into --database-url from the shell.
+	t.Setenv("DATABASE_URL", "")
+
+	serveCmd := &ServeCmd{Cfg: &config.Config{}}
+	cmd := serveCmd.Command()
+	cmd.RunE = func(*cobra.Command, []string) error { return nil }
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	// With the DB disabled, an empty DATABASE_URL must NOT fail boot.
+	cmd.SetArgs([]string{"--db-enabled=false"})
+
+	require.NoError(t, cmd.Execute())
+}
+
 func TestServeCmd_RejectsMaxLedgerKeyAddressesAboveUpstreamCeiling(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/db_health.go
+++ b/internal/api/handlers/db_health.go
@@ -37,6 +37,16 @@ func NewDBHealthHandler(db DBPinger) *DBHealthHandler {
 func (h *DBHealthHandler) CheckDBHealth(w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 
+	// A nil pinger means the database is disabled (DB_ENABLED=false / no pool
+	// opened). Report that distinctly rather than pinging a nil pool.
+	if h.db == nil {
+		resp := types.GetHealthResponse{Status: types.StatusDisabled}
+		if err := response.JSON(w, http.StatusOK, resp); err != nil {
+			return httperror.InternalServerError("error writing DB health check response", err)
+		}
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), dbHealthPingTimeout)
 	defer cancel()
 

--- a/internal/api/handlers/db_health_test.go
+++ b/internal/api/handlers/db_health_test.go
@@ -32,6 +32,23 @@ func (f *fakeDBPinger) Ping(ctx context.Context) error {
 func TestDBHealthHandler_CheckDBHealth(t *testing.T) {
 	t.Parallel()
 
+	t.Run("returns 200 and disabled when DB is not configured", func(t *testing.T) {
+		t.Parallel()
+		// nil pinger => the DB is disabled (DB_ENABLED=false / no pool opened).
+		handler := NewDBHealthHandler(nil)
+
+		req, _ := http.NewRequest("GET", "/api/v1/db-health", nil)
+		rr := httptest.NewRecorder()
+
+		err := handler.CheckDBHealth(rr, req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var resp types.GetHealthResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+		assert.Equal(t, types.StatusDisabled, resp.Status)
+	})
+
 	t.Run("returns 200 and healthy when DB is reachable", func(t *testing.T) {
 		t.Parallel()
 		handler := NewDBHealthHandler(&fakeDBPinger{err: nil})

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -77,9 +77,15 @@ func (s *ApiServer) Start() error {
 	// The database is initialized separately from initServices because it eagerly
 	// connects (to fail fast), whereas the other clients are lazy. Keeping it out
 	// of initServices keeps that function unit-testable without real infrastructure.
-	if err = s.initDatabase(); err != nil {
-		logger.Error("Failed to initialize database", "error", err)
-		return err
+	// Skipped entirely when the DB is disabled: no pool is opened and dbPool stays
+	// nil, so DB-backed features (and db-health) report unavailable.
+	if s.cfg.DatabaseConfig.Enabled {
+		if err = s.initDatabase(); err != nil {
+			logger.Error("Failed to initialize database", "error", err)
+			return err
+		}
+	} else {
+		logger.Warn("Database is disabled (--db-enabled=false); running without a database")
 	}
 	defer s.closeServices()
 
@@ -181,8 +187,14 @@ func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
 	mux.HandleFunc("GET /api/v1/rpc-health", handlers.CustomHandler(rpcHealthHandler.CheckRPCHealth))
 
 	// Initialize DB health check handler (reports connectivity in the body; never
-	// fails the request, so it can't restart or depool a pod over a DB outage)
-	dbHealthHandler := handlers.NewDBHealthHandler(s.dbPool)
+	// fails the request, so it can't restart or depool a pod over a DB outage).
+	// Pass a true nil interface when disabled — a nil *pgxpool.Pool boxed in the
+	// interface is not == nil, which would defeat the handler's disabled check.
+	var dbPinger handlers.DBPinger
+	if s.dbPool != nil {
+		dbPinger = s.dbPool
+	}
+	dbHealthHandler := handlers.NewDBHealthHandler(dbPinger)
 	mux.HandleFunc("GET /api/v1/db-health", handlers.CustomHandler(dbHealthHandler.CheckDBHealth))
 
 	protocolsHandler := handlers.NewProtocolsHandler(s.cfg.AppConfig.ProtocolsConfigPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,10 @@ type RedisConfig struct {
 // DatabaseConfig holds the PostgreSQL connection string and pgx pool tunables.
 // URL is sourced from DATABASE_URL (via ExternalSecrets in deployed envs).
 type DatabaseConfig struct {
+	// Enabled gates the whole database subsystem. When false, serve skips
+	// URL/pool validation and never opens a pool — used to run the service
+	// without a database (e.g. envs where the DB isn't provisioned yet).
+	Enabled         bool
 	URL             string
 	MaxConns        int
 	MinConns        int

--- a/internal/types/interfaces.go
+++ b/internal/types/interfaces.go
@@ -12,6 +12,10 @@ const (
 	StatusHealthy   = "healthy"
 	StatusUnhealthy = "unhealthy"
 	StatusError     = "error"
+	// StatusDisabled is reported by db-health when the database is turned off
+	// (DB_ENABLED=false / no pool opened), so probes can tell "off on purpose"
+	// apart from "configured but unreachable" (StatusUnhealthy).
+	StatusDisabled = "disabled"
 )
 
 const (


### PR DESCRIPTION
## TL;DR

Adds a `DB_ENABLED` switch so the service can run **without** a database. Right now the database is a hard dependency — the app won't start unless a Postgres is configured and reachable — which blocks deploying to any environment (e.g. prod) where the DB isn't set up yet. With `DB_ENABLED=false` the service starts normally and DB-backed health simply reports "disabled". Default is `true`, so **dev/stg behavior is unchanged** and need no edits.

This unblocks shipping other `main` changes to prod while the prod database is still being provisioned.

<details>
<summary>Implementation details (for agents)</summary>

**Background:** #110 made the DB a hard dependency — `serve` PreRunE rejects an empty `DATABASE_URL`, and `Start()` eagerly opens + pings the pool (fail-fast). Any image ≥ #110 therefore crash-loops without a reachable DB.

**Change** — new `--db-enabled` flag (env `DB_ENABLED`, default `true`):
- [`internal/config/config.go`](https://github.com/stellar/freighter-backend-v2/blob/03c8dea21ccd850da1cd6f7752405bba3d4bb296/internal/config/config.go) — `DatabaseConfig.Enabled bool`.
- [`cmd/serve/serve.go`](https://github.com/stellar/freighter-backend-v2/blob/03c8dea21ccd850da1cd6f7752405bba3d4bb296/cmd/serve/serve.go) — register the flag; PreRunE runs `Validate()`/`ValidatePoolConfig()` **only when enabled** (so empty `DATABASE_URL` no longer fails boot when disabled).
- [`internal/api/serve.go`](https://github.com/stellar/freighter-backend-v2/blob/03c8dea21ccd850da1cd6f7752405bba3d4bb296/internal/api/serve.go) — `Start()` skips `initDatabase()` when disabled (`dbPool` stays nil; logs a warning). db-health is given a **true nil** `DBPinger` when the pool is nil (a nil `*pgxpool.Pool` boxed in the interface is not `== nil`, which would defeat the disabled check).
- [`internal/api/handlers/db_health.go`](https://github.com/stellar/freighter-backend-v2/blob/03c8dea21ccd850da1cd6f7752405bba3d4bb296/internal/api/handlers/db_health.go) — nil pinger → `{"status":"disabled"}` (200), distinct from `unhealthy` (configured-but-unreachable).
- `internal/types/interfaces.go` — `StatusDisabled = "disabled"`.

**Behavior matrix:**
| `DB_ENABLED` | `DATABASE_URL` | result |
|---|---|---|
| true (default) | set | unchanged: validate, open pool, fail fast on error |
| true | empty | boot fails (`database-url required`) — unchanged safety net |
| false | anything | no validation, no pool; `db-health` → `disabled` |

**Tests (TDD, all watched fail first):** flag defaults true; empty `DATABASE_URL` accepted when disabled; db-health returns `disabled` on nil pinger. Full unit suite green; `go build`/`vet`/`gofmt` clean.

**Safe because** nothing uses the pool yet (only db-health pings it) — no feature route touches the DB. When Contact Sync lands, make the DB required for that feature specifically rather than reinstating a global hard dependency.

**Deploy note:** to run an env without a DB, set `DB_ENABLED=false` in its config. Envs that should have a DB keep the default and retain fail-fast.

</details>
