### PR TITLE
fix(balances): derive is_funded from native balance, hide balances when unfunded

### DIFF
--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -191,7 +191,8 @@ func (w *walletBackendService) GetBalancesByAccountAddresses(ctx context.Context
 			// even if a future SDK regression returned nil for an account with zero
 			// balances. GetAllAccountBalances currently returns a non-nil empty
 			// slice; keeping the guard is cheap insurance. IsFunded defaults to
-			// false and is set true only on a successful fetch (below).
+			// false and is set true only when the fetched balances include a
+			// native balance (below).
 			ab := &types.AccountBalances{
 				Address:  addr,
 				Balances: []types.Balance{},
@@ -215,22 +216,30 @@ func (w *walletBackendService) GetBalancesByAccountAddresses(ctx context.Context
 				// breadcrumb, matching the metrics layer's non-error treatment.
 				logger.InfoWithContext(gctx, "account not found", "address", addr)
 			} else {
-				// A successful fetch means the account exists on-chain, so it is
-				// funded. Not-found leaves IsFunded false; systemic errors return
-				// above and never yield a result — so funded is derived from a real
-				// success, not from the absence of an error, and stays correct even
-				// if the error handling above changes.
-				ab.IsFunded = true
-				mapped := make([]types.Balance, 0, len(balances))
+				// "Funded" means the classic account exists, which on-chain is exactly
+				// the presence of a native balance. A successful fetch only proves
+				// wallet-backend has data for the address — which also holds for merged
+				// accounts (history but no classic account) and holders of only Soroban
+				// tokens. So derive IsFunded from the native balance rather than from the
+				// fetch succeeding, hoisting SubentryCount from the same entry.
 				for _, b := range balances {
-					// SubentryCount is hoisted from the single native balance;
-					// it stays 0 for accounts without one (e.g. unfunded views).
+					// There is at most one native balance per account; stop once found.
 					if nb, ok := b.(*wbtypes.NativeBalance); ok {
+						ab.IsFunded = true
 						ab.SubentryCount = nb.NumSubentries
+						break
 					}
-					mapped = append(mapped, mapBalance(b))
 				}
-				ab.Balances = mapped
+				// Only surface balances for a funded account: an account with no classic
+				// account is reported as unfunded with an empty balance set, so any
+				// residual Soroban token balances it holds are not exposed here.
+				if ab.IsFunded {
+					mapped := make([]types.Balance, 0, len(balances))
+					for _, b := range balances {
+						mapped = append(mapped, mapBalance(b))
+					}
+					ab.Balances = mapped
+				}
 			}
 			results[i] = ab
 			return nil

--- a/internal/services/wallet_backend.go
+++ b/internal/services/wallet_backend.go
@@ -152,11 +152,13 @@ func (w *walletBackendService) configureNetworkClient(network string) *wbclient.
 //
 //   - Duplicate input addresses collapse to a single result while preserving
 //     first-seen order.
-//   - The single address-scoped outcome is the typed
-//     wbclient.ErrAccountNotFound sentinel (accountByAddress:null upstream):
-//     it sets is_funded=false (with an empty balances slice) on that account's
-//     result while other accounts in the same request still return their
-//     balances.
+//   - is_funded is derived from the presence of a native balance, so an account
+//     is reported unfunded (is_funded=false with an empty balances slice) via two
+//     address-scoped paths, while other accounts in the same request still return
+//     their balances: the typed wbclient.ErrAccountNotFound sentinel
+//     (accountByAddress:null upstream — the account isn't indexed), and a
+//     successful fetch whose balances contain no native entry (a merged or
+//     contract-token-only account with no classic account).
 //   - Every other failure is systemic and returned as a top-level error so
 //     the handler emits a 5xx and monitoring sees the outage rather than a
 //     200 that hides it. This includes GraphQL errors[]
@@ -222,22 +224,18 @@ func (w *walletBackendService) GetBalancesByAccountAddresses(ctx context.Context
 				// accounts (history but no classic account) and holders of only Soroban
 				// tokens. So derive IsFunded from the native balance rather than from the
 				// fetch succeeding, hoisting SubentryCount from the same entry.
+				mapped := make([]types.Balance, 0, len(balances))
 				for _, b := range balances {
-					// There is at most one native balance per account; stop once found.
 					if nb, ok := b.(*wbtypes.NativeBalance); ok {
 						ab.IsFunded = true
 						ab.SubentryCount = nb.NumSubentries
-						break
 					}
+					mapped = append(mapped, mapBalance(b))
 				}
 				// Only surface balances for a funded account: an account with no classic
 				// account is reported as unfunded with an empty balance set, so any
 				// residual Soroban token balances it holds are not exposed here.
 				if ab.IsFunded {
-					mapped := make([]types.Balance, 0, len(balances))
-					for _, b := range balances {
-						mapped = append(mapped, mapBalance(b))
-					}
 					ab.Balances = mapped
 				}
 			}

--- a/internal/services/wallet_backend_test.go
+++ b/internal/services/wallet_backend_test.go
@@ -627,6 +627,36 @@ func TestGetBalancesByAccountAddresses_EnvelopeEnrichment(t *testing.T) {
 		assert.EqualValues(t, 0, results[0].SubentryCount)
 		assert.Empty(t, results[0].Balances)
 	})
+
+	t.Run("unfunded_account_with_only_contract_balance_hides_balances", func(t *testing.T) {
+		// A successful fetch returning only a SEP-41 (Soroban) balance and no native
+		// balance means the account has no classic account: is_funded=false,
+		// subentry_count=0, and no balances surfaced (an unfunded account exposes no
+		// balances). "Fetch succeeded" must not be mistaken for "funded".
+		sep41Only := `{
+			"data": {"accountByAddress": {"balances": {
+				"edges": [{"node": {
+					"__typename": "SEP41Balance",
+					"balance": "5000000000", "tokenId": "CDMLFMKMMD7MWZP3FKUBZPVHTUEDLSX4BYGYKH4GCESXYHS3IHQ4EIG4",
+					"tokenType": "SEP41", "name": "SEP41 Token", "symbol": "SEP41",
+					"decimals": 7, "lastModifiedLedger": 12345
+				}}],
+				"pageInfo": {"hasNextPage": false, "endCursor": null}
+			}}}
+		}`
+		f := newFanoutFakeServer(t, func(_ string, _ *string) (int, string) {
+			return http.StatusOK, sep41Only
+		})
+		svc := newFanoutTestService(f.server.URL, 10)
+
+		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA}, types.PUBLIC)
+		require.NoError(t, err)
+		results := raw.([]*types.AccountBalances)
+		require.Len(t, results, 1)
+		assert.False(t, results[0].IsFunded, "no native balance -> unfunded even though the fetch succeeded")
+		assert.EqualValues(t, 0, results[0].SubentryCount)
+		assert.Empty(t, results[0].Balances, "unfunded account exposes no balances")
+	})
 }
 
 // txResponder builds a fake response for the GetAccountTransactions GraphQL query.

--- a/internal/services/wallet_backend_test.go
+++ b/internal/services/wallet_backend_test.go
@@ -610,6 +610,54 @@ func TestGetBalancesByAccountAddresses_EnvelopeEnrichment(t *testing.T) {
 		assert.Equal(t, "97.5000000", native.Available)
 	})
 
+	t.Run("funded_account_surfaces_native_and_non_native_balances", func(t *testing.T) {
+		// A funded account must surface ALL its balances, not just the native entry
+		// that drives is_funded. A native + SEP-41 fixture guards against the funded
+		// path accidentally being narrowed to native-only.
+		nativeAndSep41 := `{
+			"data": {"accountByAddress": {"balances": {
+				"edges": [
+					{"node": {
+						"__typename": "NativeBalance",
+						"balance": "100.0000000", "tokenId": "native", "tokenType": "NATIVE",
+						"minimumBalance": "1.0000000", "buyingLiabilities": "0.0000000", "sellingLiabilities": "0.0000000",
+						"lastModifiedLedger": 100, "numSubentries": 3
+					}},
+					{"node": {
+						"__typename": "SEP41Balance",
+						"balance": "5000000000", "tokenId": "CDMLFMKMMD7MWZP3FKUBZPVHTUEDLSX4BYGYKH4GCESXYHS3IHQ4EIG4",
+						"tokenType": "SEP41", "name": "SEP41 Token", "symbol": "SEP41",
+						"decimals": 7, "lastModifiedLedger": 12345
+					}}
+				],
+				"pageInfo": {"hasNextPage": false, "endCursor": null}
+			}}}
+		}`
+		f := newFanoutFakeServer(t, func(_ string, _ *string) (int, string) {
+			return http.StatusOK, nativeAndSep41
+		})
+		svc := newFanoutTestService(f.server.URL, 10)
+
+		raw, err := svc.GetBalancesByAccountAddresses(context.Background(), []string{addrA}, types.PUBLIC)
+		require.NoError(t, err)
+		results := raw.([]*types.AccountBalances)
+		require.Len(t, results, 1)
+		assert.True(t, results[0].IsFunded)
+		assert.EqualValues(t, 3, results[0].SubentryCount)
+		require.Len(t, results[0].Balances, 2, "funded account must surface all balances, not just native")
+		var sawNative, sawSEP41 bool
+		for _, b := range results[0].Balances {
+			switch b.(type) {
+			case *types.NativeBalance:
+				sawNative = true
+			case *types.SEP41Balance:
+				sawSEP41 = true
+			}
+		}
+		assert.True(t, sawNative, "native balance must be surfaced")
+		assert.True(t, sawSEP41, "non-native (SEP-41) balance must be surfaced for a funded account")
+	})
+
 	t.Run("account_not_found_sets_is_funded_false", func(t *testing.T) {
 		// ErrAccountNotFound is address-scoped: is_funded=false,
 		// subentry_count=0, and an empty balances slice (no per-account error —

--- a/internal/types/wallet_backend.go
+++ b/internal/types/wallet_backend.go
@@ -13,14 +13,17 @@ import (
 // AccountBalances values, one per unique input address (duplicates are collapsed
 // while preserving first-seen order).
 //
-// Wire format: address is the canonical Stellar account ID, is_funded reports
-// whether the account exists on-ledger (false when the account isn't found),
-// subentry_count is hoisted from the native balance, and balances is always a
-// non-nil slice (an account with no balances marshals to "balances": []).
+// Wire format: address is the canonical Stellar account ID; is_funded reports
+// whether the classic account exists — true iff the account has a native balance;
+// subentry_count is hoisted from that native balance; and balances is always a
+// non-nil slice (an unfunded account, or one with no balances, marshals to
+// "balances": []).
 //
-// The one address-scoped outcome — the account not existing (the typed
-// wbclient.ErrAccountNotFound sentinel, accountByAddress:null upstream) — is
-// conveyed by is_funded=false, not a per-account error. Every other failure
+// An account is reported unfunded (is_funded=false, empty balances) via two
+// address-scoped paths, neither a per-account error: the account isn't indexed
+// (the typed wbclient.ErrAccountNotFound sentinel, accountByAddress:null
+// upstream), or a successful fetch returns no native balance (a merged or
+// contract-token-only account with no classic account). Every other failure
 // (GraphQL errors[] from the server, HTTP 4xx/5xx, transport, signing,
 // request-level cancellation) surfaces as a top-level error from the service,
 // so monitoring sees real outages instead of a 200 that hides them.


### PR DESCRIPTION
## Problem

`GetBalancesByAccountAddresses` set `is_funded=true` on any successful wallet-backend fetch, equating "wallet-backend has data for this address" with "the account is funded". That's wrong for:
- **merged accounts** — history but no classic account,
- **never-created addresses**,
- **contract-token-only holders** — hold Soroban tokens, no classic account.

(An earlier attempt fixed this in wallet-backend by returning `accountByAddress: null` for such accounts, but that also nulled their transactions/state-changes — every account-scoped query gates on `accountByAddress == nil` — breaking the account view for merged accounts. So the fix belongs here, where the wrong assumption lives.)

## Fix

Derive `is_funded` from the presence of a `NativeBalance` in the returned balances — the classic account exists iff it has a native balance — and hoist `subentry_count` from that same entry. An unfunded account (no native balance) is reported with an empty balance set: any residual Soroban token balances it holds are not surfaced.

wallet-backend still serves the account's transactions/state-changes for merged accounts; this change only governs the balances envelope.

## Effect

- funded account → `is_funded=true`, balances shown (unchanged).
- merged / never-created / contract-token-only → `is_funded=false`, empty balances (was wrongly `is_funded=true`).

## Testing

- New `unfunded_account_with_only_contract_balance_hides_balances`: a successful fetch with only a SEP-41 balance → `is_funded=false`, `subentry_count=0`, empty balances.
- Existing envelope/fan-out tests unchanged. `go test -race ./...`, whole-repo tests, and `make lint` (0 issues) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
