### PR TITLE
feat(auth): apply auth middleware to all user-facing routes (#114)

### DIFF
--- a/docs/design/2026-06-22-jwt-auth-middleware.md
+++ b/docs/design/2026-06-22-jwt-auth-middleware.md
@@ -25,6 +25,12 @@ Every user-facing `/api/v1` route runs the auth middleware. Infra health probes 
 - **Verify-only:** clients sign, the server verifies. No signing/generator code, no key/secret
   config.
 
+Because identity is self-asserted, a valid JWT only proves possession of *some* Ed25519 keypair —
+anyone can mint one — so auth (even in `strict`) is **not** an anti-sybil or rate-limiting control.
+It raises the bar for casual/anonymous abuse but does not bound how many identities a caller can
+present; endpoints that need abuse protection (e.g. anything hitting a metered upstream) still
+require their own per-route limits or quotas on top of auth.
+
 ## Modes and rollout
 
 Shipped Freighter clients today send **no** JWT; newer client versions send a JWT on every request.
@@ -46,9 +52,12 @@ config change.
 
 ## Route coverage
 
-Auth is applied **per route**: one `middleware.Auth(verifier, s.authMode, metrics)` value is bound
-to the configured mode and wraps each user-facing route at its registration site in
-`internal/api/serve.go`.
+Auth is applied **per route**, driven by a single route table (`routes()` in
+`internal/api/serve.go`). Each entry declares a `gated` flag; `initHandlers` iterates the table and
+wraps every `gated` route with one shared `middleware.Auth(verifier, s.authMode, metrics)` value
+bound to the configured mode. The table is the single source of truth for gating — the strict-mode
+guard test enumerates the same `routes()`, so a newly-added route is auto-covered and a route added
+`gated: false` is a visible, reviewable decision rather than a silent fail-open.
 
 - **Gated (user-facing):** `/api/v1/protocols`, `/api/v1/collectibles`,
   `/api/v1/ledger-key/accounts`, `/api/v1/feature-flags`, `/api/v1/accounts/balances`,
@@ -62,8 +71,10 @@ Because auth wraps the handler *inside* the mux, it runs **after** routing — s
 `Logging`/`Metrics` middleware (which are outer, wrapping the whole mux) capture auth 401s, and the
 HTTP metrics `handler` label (from `r.Pattern`) stays correct for authenticated requests.
 
-A future user-scoped route can opt into `auth.Required` independently of the global mode by wrapping
-with its own `Auth` value — e.g. `middleware.Auth(verifier, auth.Required, m)(contactsHandler)`.
+A future user-scoped route that needs a policy *different* from the global mode (e.g. always
+`auth.Required` regardless of `AUTH_MODE`) would wrap explicitly with its own `Auth` value —
+e.g. `middleware.Auth(verifier, auth.Required, m)(contactsHandler)` — rather than relying on the
+shared `authed` the table applies to every `gated` route.
 
 ## Architecture
 
@@ -80,7 +91,7 @@ internal/api/middleware/auth.go    Auth(verifier, mode, metrics) Middleware; 401
 internal/api/handlers/whoami.go    echoes the authenticated userID (auth smoke-test surface)
 internal/config/config.go          AuthMode field (permissive|strict), validated at load
 internal/metrics/metrics.go        auth counter (adoption/rejection signal)
-internal/api/serve.go              per-route Auth wrapping in initHandlers; health routes bare
+internal/api/serve.go              routes() table + per-route Auth wrapping in initHandlers; health routes gated=false (bare)
 ```
 
 **Boundaries:** `internal/auth` owns the *mechanism* (is this token cryptographically valid for its

--- a/docs/design/2026-06-22-jwt-auth-middleware.md
+++ b/docs/design/2026-06-22-jwt-auth-middleware.md
@@ -1,93 +1,91 @@
-# JWT Auth Middleware — Design
+# JWT Authentication — Design
 
-- **Ticket:** [stellar/freighter-backend-v2#88](https://github.com/stellar/freighter-backend-v2/issues/88)
-- **Reference:** [Freighter Unified User Model Storage](https://github.com/stellar/wallet-eng-monorepo/blob/main/design-docs/contact-lists/Freighter%20Unified%20User%20Model%20Storage.md) — user ID derivation + auth flow + JWT claims
-- **Date:** 2026-06-22
-- **Status:** Approved (design), implementing
+- **Tickets:** [#88](https://github.com/stellar/freighter-backend-v2/issues/88) (verifier + middleware), [#114](https://github.com/stellar/freighter-backend-v2/issues/114) (applied to all user-facing routes)
+- **Reference:** [Freighter Unified User Model Storage](https://github.com/stellar/wallet-eng-monorepo/blob/main/design-docs/contact-lists/Freighter%20Unified%20User%20Model%20Storage.md) — user ID derivation, auth flow, JWT claims
+- **Last updated:** 2026-07-10
+- **Status:** Current
 
 ## Summary
 
-Add a stateless Ed25519/JWT authentication primitive to `freighter-backend-v2`, modeled on
-`wallet-backend`'s `JWTManager` pattern but adapted for a **self-asserted identity** model: the
-JWT's `sub` claim *is* the caller's **unified user ID** — a hex-encoded Ed25519 public key derived
-from the user's seed, which doubles as the signature-verification key — and the server verifies each
-request's signature against it. No registration, no session state, no DB lookup, **no server-side key
-or secret to provision**.
+`freighter-backend-v2` authenticates requests with a stateless Ed25519/JWT primitive using a
+**self-asserted identity** model: the JWT's `sub` claim *is* the caller's **unified user ID** — a
+hex-encoded Ed25519 public key derived from the user's seed, which doubles as the
+signature-verification key. The server verifies each request's signature against `sub`. There is no
+registration, no session state, no DB lookup, and **no server-side key or secret to provision**.
 
-This ticket delivers the **verifier + middleware only**. It is feature-agnostic — it does not gate
-any existing production endpoint, and any feature that wants authenticated requests builds on it
-later. Existing endpoints keep working unchanged.
+Every user-facing `/api/v1` route runs the auth middleware. Infra health probes do not.
 
-## Scope
+## Identity model
 
-In scope:
-- A pure verifier package (`internal/auth`) that, given an `*http.Request`, returns the authenticated
-  `userID` or a typed error.
-- An HTTP middleware (`internal/api/middleware/auth.go`) with two modes (permissive / required).
-- A global config field (`AuthMode`) that selects the mode, defaulting to permissive.
-- Auth adoption/rejection metrics.
-- A minimal guarded endpoint (`GET /api/v1/auth/whoami`) to exercise the middleware end-to-end and
-  give client teams a surface to validate JWT construction against. *(Optional — can be dropped if
-  reviewers prefer zero new production routes; acceptance is also covered by middleware tests.)*
+- The unified user ID is a **hex-encoded raw Ed25519 public key** (32 bytes), derived from the
+  user's seed via HMAC. It is deliberately *not* a valid Stellar `G...` strkey address.
+- The verification key is **self-asserted**: it *is* the `sub` claim. There is no configured or
+  allowlisted server key to compare against — validity means "this token is cryptographically
+  signed by the private key matching the public key it claims as its identity."
+- **Verify-only:** clients sign, the server verifies. No signing/generator code, no key/secret
+  config.
 
-Out of scope (future tickets):
-- Any feature endpoints/schema that consume the authenticated user ID.
-- Gating existing endpoints (`/accounts/balances`, `/protocols`, etc.).
-- The final permissive→strict cutover.
+## Modes and rollout
 
-## Rollout model (why two modes)
-
-Shipped Freighter clients today send **no** JWT. New client versions will send a JWT on every
-request. We cannot break old clients, so gated endpoints go through a transition:
+Shipped Freighter clients today send **no** JWT; newer client versions send a JWT on every request.
+To avoid breaking old clients, auth has two modes, selected by one global config value
+(`AUTH_MODE` / `--auth-mode`, default `permissive`):
 
 | Mode | No `Authorization` header | Header present, valid | Header present, invalid |
 | --- | --- | --- | --- |
-| **public** (ungated) | pass | pass | pass |
-| **permissive** (transition, default) | pass (anonymous, no `userID`) | pass (+`userID`) | **401** |
-| **required** (post-rollout) | **401** | pass (+`userID`) | **401** |
+| **permissive** (default) | pass (anonymous, no `userID`) | pass (+`userID`) | **401** |
+| **strict** (`auth.Required`) | **401** | pass (+`userID`) | **401** |
 
-A present-but-invalid token is **always** rejected (401) — only updated clients send tokens, so a bad
-token is a real bug or attack, and rejecting it keeps ticket #88's acceptance criteria true in every
-mode while giving clean adoption signal during rollout.
+A present-but-invalid token is **always** rejected (401) in both modes — only updated clients send
+tokens, so a bad token is a real bug or attack, and rejecting it gives clean adoption signal during
+rollout.
 
-All gated endpoints share one mode and flip together (client adoption is per-app-version, not
-per-endpoint), so the mode is a single global config value, not a per-route argument. The cutover is
-one config change.
+All user-facing routes share one mode and flip together (client adoption is per-app-version, not
+per-endpoint), so the mode is a single global config value. The permissive→strict cutover is one
+config change.
+
+## Route coverage
+
+Auth is applied **per route**: one `middleware.Auth(verifier, s.authMode, metrics)` value is bound
+to the configured mode and wraps each user-facing route at its registration site in
+`internal/api/serve.go`.
+
+- **Gated (user-facing):** `/api/v1/protocols`, `/api/v1/collectibles`,
+  `/api/v1/ledger-key/accounts`, `/api/v1/feature-flags`, `/api/v1/accounts/balances`,
+  `/api/v1/token-prices`, `/api/v1/accounts/{address}/transactions`, `/api/v1/auth/whoami`.
+- **Anonymous in every mode (registered bare, never wrapped):** the infra liveness/readiness
+  probes `/api/v1/ping`, `/api/v1/db-health`, `/api/v1/rpc-health`. K8s and the docker-compose
+  healthcheck cannot present per-request JWTs, and `db-health` is designed never to fail the
+  request; gating any of these would 401 probes under `strict` and cause pod churn.
+
+Because auth wraps the handler *inside* the mux, it runs **after** routing — so the global
+`Logging`/`Metrics` middleware (which are outer, wrapping the whole mux) capture auth 401s, and the
+HTTP metrics `handler` label (from `r.Pattern`) stays correct for authenticated requests.
+
+A future user-scoped route can opt into `auth.Required` independently of the global mode by wrapping
+with its own `Auth` value — e.g. `middleware.Auth(verifier, auth.Required, m)(contactsHandler)`.
 
 ## Architecture
 
 ```
-internal/auth/                     NEW — pure verifier primitive, no HTTP/config/metrics deps
+internal/auth/                     pure verifier primitive — no HTTP/config/metrics deps
   claims.go      Claims struct + Validate(methodAndPath, body, maxLifetime)
   parser.go      ParseJWT: read sub → hex-decode → ed25519 key → verify sig (EdDSA only) + leeway
   verifier.go    HTTPRequestVerifier interface + VerifyHTTPRequest(req) (userID, error)
-  errors.go      ErrNoToken (sentinel), ErrUnauthorized, ExpiredTokenError
+  mode.go        Mode enum (Permissive|Required) + ParseMode("permissive"|"strict")
+  errors.go      ErrNoToken (sentinel), ErrUnauthorized, VerificationError + Reason
   helpers.go     HashBody (SHA-256 hex)
   context.go     ContextWithUserID / UserIDFromContext
-  *_test.go      table-driven unit tests + a test-only token signer
-
-internal/api/middleware/auth.go    NEW — Auth(verifier, mode) Middleware; 401 via httperror; injects userID
-internal/api/handlers/whoami.go    NEW (optional) — echoes authenticated userID
-internal/config/config.go          + AuthMode field (permissive|strict), validated at load
-internal/metrics/metrics.go        + auth counter (adoption/rejection signal)
-internal/api/serve.go              wire Auth(verifier, cfg.AuthMode) onto the whoami route
+internal/api/middleware/auth.go    Auth(verifier, mode, metrics) Middleware; 401 via httperror; injects userID
+internal/api/handlers/whoami.go    echoes the authenticated userID (auth smoke-test surface)
+internal/config/config.go          AuthMode field (permissive|strict), validated at load
+internal/metrics/metrics.go        auth counter (adoption/rejection signal)
+internal/api/serve.go              per-route Auth wrapping in initHandlers; health routes bare
 ```
 
 **Boundaries:** `internal/auth` owns the *mechanism* (is this token cryptographically valid for its
-claimed identity?). The middleware owns the *policy* (which mode, what to do per outcome, how to
-render 401, what to record). The verifier is HTTP-aware only insofar as it reads an `*http.Request`;
-it has no knowledge of config, metrics, or middleware.
-
-### Divergences from wallet-backend (by necessity)
-
-1. `sub` is the **unified user ID** — a **hex-encoded raw Ed25519** public key (32 bytes), not a
-   strkey `G...` address — so no `strkey` calls; `hex.DecodeString` → `ed25519.PublicKey`. The user ID
-   is derived from the seed via HMAC and is deliberately *not* a valid Stellar address.
-2. The verification key is **self-asserted** (it *is* the `sub` / user ID), not compared against a
-   configured/allowlisted server key. wallet-backend's `ParseJWT` rejects any `sub != m.PublicKey`;
-   that check is removed.
-3. Adds **±5s leeway** (`jwt.WithLeeway`) for mobile clock skew, per the design doc.
-4. **Verify-only.** No signing/generator code and no key/secret config — clients sign, server verifies.
+claimed identity?). The middleware owns the *policy* (mode, per-outcome behavior, 401 rendering,
+metrics). The verifier is HTTP-aware only insofar as it reads an `*http.Request`.
 
 ## Verifier internals
 
@@ -95,61 +93,60 @@ it has no knowledge of config, metrics, or middleware.
 type Claims struct {
     BodyHash      string `json:"bodyHash"`
     MethodAndPath string `json:"methodAndPath"`
-    jwtgo.RegisteredClaims // Subject (hex unified user ID = Ed25519 pubkey), Issuer, IssuedAt, ExpiresAt
+    jwtgo.RegisteredClaims // Subject (hex user ID = Ed25519 pubkey), Issuer, IssuedAt, ExpiresAt
 }
 ```
 
-Constants: `MaxTokenLifetime = 15s`, `ClockSkewLeeway = 5s`. The verifier imposes no
-body-size limit of its own: request bodies are already bounded upstream by the
-`BodySizeLimit` middleware (`http.MaxBytesReader`), so it reads them in full rather than
-risk silently truncating the bytes it hashes.
+Constants: `MaxTokenLifetime = 15s`, `ClockSkewLeeway = 5s`. The verifier imposes no body-size
+limit of its own — request bodies are bounded upstream by the `BodySizeLimit` middleware
+(`http.MaxBytesReader`), so it reads them in full rather than risk truncating the bytes it hashes.
 
 `ParseJWT(tokenString, methodAndPath, body)`:
 1. `ParseUnverified` to read `claims.Subject`.
 2. `claims.Validate(methodAndPath, body, MaxTokenLifetime)`:
    - `exp` and `iat` set; `exp - iat ≤ MaxTokenLifetime`;
    - `iat` not in the future beyond `ClockSkewLeeway`, and `exp` not beyond
-     `now + MaxTokenLifetime + ClockSkewLeeway` (keeps the acceptance window
-     within the intended lifetime ± skew — `WithLeeway` alone does not bound a
-     future `iat`);
-   - `methodAndPath` matches `"<METHOD> <RequestURI>"` (binds query string);
+     `now + MaxTokenLifetime + ClockSkewLeeway`;
+   - `methodAndPath` matches `"<METHOD> <RequestURI>"` (binds the query string);
    - `bodyHash == HashBody(body)`.
-3. Decode `Subject` → `ed25519.PublicKey` (valid hex decoding to exactly
-   `ed25519.PublicKeySize` (32) bytes; performed in `ParseJWT` after `Validate`,
-   not inside `Claims.Validate`).
-4. `jwtgo.ParseWithClaims(..., keyfunc→pubKey, jwtgo.WithValidMethods([]string{"EdDSA"}), jwtgo.WithLeeway(ClockSkewLeeway))`.
+3. Decode `Subject` → `ed25519.PublicKey` (hex decoding to exactly 32 bytes).
+4. `jwtgo.ParseWithClaims(..., keyfunc→pubKey, WithValidMethods([]string{"EdDSA"}), WithLeeway(ClockSkewLeeway))`.
    `WithValidMethods` blocks `alg=none`/HS256 confusion attacks.
-5. Map `jwtgo.ErrTokenExpired` → `ExpiredTokenError`.
 
 `VerifyHTTPRequest(req) (userID string, err error)`:
-- Missing/`non-Bearer` `Authorization` header → `ErrNoToken` (distinct sentinel, **not** wrapping
+- Missing/non-Bearer `Authorization` header → `ErrNoToken` (distinct sentinel, **not** wrapping
   `ErrUnauthorized`) so the middleware can tell "no token" (anonymous-eligible) from "bad token".
-- Read the full body, then reset `req.Body` so handlers can read it. Accept a case-insensitive `Bearer` scheme (RFC 6750).
+  A `Bearer` scheme with an empty credential is a bad token, not "no token".
+- Read the full body, then reset `req.Body` so handlers can read it. `Bearer` scheme is
+  case-insensitive (RFC 6750).
 - `methodAndPath = fmt.Sprintf("%s %s", req.Method, req.URL.RequestURI())`.
-- On success returns `userID = claims.Subject` (the hex unified user ID). Invalid-token errors wrap `ErrUnauthorized`.
+- On success returns `userID = claims.Subject`. Invalid-token errors wrap `ErrUnauthorized`.
 
 ## Middleware, modes, error handling
 
-`auth.Mode` enum: `Permissive`, `Required`. `internal/config` parses the string `AuthMode`
+`auth.Mode` enum: `Permissive`, `Required`. `internal/config` parses `AuthMode`
 (`permissive`|`strict`, default `permissive`) into it and **fails config load on unknown values**.
+The resolved mode is stored once on the server (`s.authMode`) and bound into the shared `Auth`
+value used to wrap routes.
 
 ```go
-func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode) Middleware {
+func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, m *metrics.Auth) Middleware {
     return func(next http.Handler) http.Handler {
         return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
             userID, err := verifier.VerifyHTTPRequest(r)
             switch {
             case err == nil:
+                metrics.RecordAuth(m, "authenticated", "ok")
                 r = r.WithContext(auth.ContextWithUserID(r.Context(), userID))
             case errors.Is(err, auth.ErrNoToken):
-                if mode == auth.Required {
-                    /* record rejected; */ httperror.Unauthorized("", nil).Render(w); return
-                }
-                // permissive: pass through anonymously, no userID
+                if mode == auth.Required { /* record rejected */ httperror.Unauthorized(...).Render(w); return }
+                metrics.RecordAuth(m, "anonymous", "no_token") // permissive: pass through
             case errors.Is(err, auth.ErrUnauthorized):
-                /* record rejected; */ httperror.Unauthorized("", nil).Render(w); return
+                /* record rejected + log reason */ httperror.Unauthorized(...).Render(w); return
+            case middleware.IsMaxBytesError(err):
+                /* record rejected */ httperror.RequestEntityTooLarge(...).Render(w); return
             default:
-                /* operational error (e.g. body read) */ httperror.InternalServerError(...).Render(w); return
+                /* operational error */ httperror.InternalServerError(...).Render(w); return
             }
             next.ServeHTTP(w, r)
         })
@@ -157,41 +154,38 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode) Middleware {
 }
 ```
 
-- 401s use v2's `httperror.Unauthorized`, compatible with the `BufferedResponseWriter` from logging
-  middleware (same pattern as `CustomHandler`).
-- Auth is applied **per-route** by wrapping the handler at registration, so the global
-  `Logging`/`Metrics` middleware (outer) naturally capture auth rejections.
+401s use v2's `httperror.Unauthorized`, compatible with the `BufferedResponseWriter` from the
+logging middleware.
 
 ## Observability
 
 - Metric: `freighter_auth_requests_total{result, reason}` counter.
   - `result ∈ {authenticated, anonymous, rejected}` — adoption % during rollout.
   - `reason ∈ {ok, no_token, expired, bad_signature, bad_timing, bad_method_path, bad_body_hash,
-    bad_subject, malformed, invalid, internal}` — a bounded set of fixed *categories* (never a
-    request value like the path or body hash), so rejection spikes can be triaged by cause
-    (client clock skew vs. body-hash bug vs. forged signature) without high label cardinality.
-- Logging: each rejection is logged via `logger` at info with `reason`, the failure `detail`, and the
-  request method/path — **never** the token or body bytes.
+    bad_subject, malformed, invalid, too_large, internal}` — a bounded set of fixed *categories*
+    (never a request value like the path or body hash), so rejection spikes can be triaged by cause
+    without high label cardinality.
+- Logging: each rejection is logged via `logger` at info with `reason`, the failure `detail`, and
+  the request method/path — **never** the token or body bytes.
 
 ## Testing
 
-- **auth pkg unit tests** (table-driven), using a test-only signer helper that mints tokens with a
-  generated ed25519 keypair:
-  - `claims.Validate`: expired, future-dated, `exp-iat` too long, mismatched `methodAndPath`,
-    mismatched `bodyHash`, non-hex `sub`, wrong-length `sub`.
-  - `ParseJWT`: valid; tampered payload; wrong signing key; `alg=none`/HS256 rejected; expired →
-    `ExpiredTokenError`; ±5s leeway boundary.
-  - `VerifyHTTPRequest`: missing header → `ErrNoToken`; bad Bearer prefix; body-hash binding; query
-    string binding; body reset after read.
-- **middleware tests**: the full truth table — for each mode × {no header, valid, expired, tampered,
-  wrong-key}, assert status (200/401) and presence/absence of `userID` in context.
-- Acceptance (#88): valid → 200, expired/tampered/wrong-key → 401, covered by middleware tests in
-  required mode (and permissive present-but-invalid → 401).
+- **auth pkg unit tests** (table-driven), using a test-only signer that mints tokens with a
+  generated ed25519 keypair: `claims.Validate` (expired, future-dated, over-long lifetime,
+  mismatched `methodAndPath`/`bodyHash`, non-hex/wrong-length `sub`); `ParseJWT` (valid, tampered,
+  wrong key, `alg=none`/HS256 rejected, expired, leeway boundary); `VerifyHTTPRequest` (missing
+  header → `ErrNoToken`, bad Bearer prefix, body-hash binding, query-string binding, body reset).
+- **middleware tests:** the full truth table — for each mode × {no header, valid, expired,
+  tampered, wrong-key}, assert status (200/401) and presence/absence of `userID` in context.
+- **route wiring tests** (`internal/api`): user-facing routes reject anonymous in strict, reject
+  invalid tokens in permissive, and expose `userID` on a valid token; health probes stay anonymous
+  in every mode; an authenticated request keeps its real route label in `freighter_http_requests_total`.
 
 ## Operational notes
 
-- New env/config var: `AUTH_MODE` (default `permissive`).
-- New route (if `whoami` kept): `GET /api/v1/auth/whoami`.
-- New metric: `freighter_auth_requests_total`.
-- These should be reflected in `wallet-eng-runbooks` when the endpoint/metric ship (handled via the
-  runbook reconcile step).
+- Config var: `AUTH_MODE` / `--auth-mode` (default `permissive`).
+- Route: `GET /api/v1/auth/whoami` (auth smoke-test surface).
+- Metric: `freighter_auth_requests_total`.
+- Under `strict`, all user-facing `/api/v1` routes return 401 without a valid JWT; health probes
+  remain anonymous. Reflect endpoint/metric/behavior changes in `wallet-eng-runbooks` via the
+  runbook reconcile step.

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -9,30 +9,18 @@ import (
 	"testing"
 	"time"
 
-	jwtgo "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/freighter-backend-v2/internal/auth"
+	"github.com/stellar/freighter-backend-v2/internal/auth/authtest"
 )
 
 const authTestPath = "/api/v1/auth/whoami"
 
 func mintToken(t *testing.T, priv ed25519.PrivateKey, sub, methodAndPath string, lifetime time.Duration, issuedAt time.Time) string {
 	t.Helper()
-	c := auth.Claims{
-		BodyHash:      auth.HashBody(nil),
-		MethodAndPath: methodAndPath,
-		RegisteredClaims: jwtgo.RegisteredClaims{
-			Subject:   sub,
-			Issuer:    "freighter-extension",
-			IssuedAt:  jwtgo.NewNumericDate(issuedAt),
-			ExpiresAt: jwtgo.NewNumericDate(issuedAt.Add(lifetime)),
-		},
-	}
-	s, err := jwtgo.NewWithClaims(jwtgo.SigningMethodEdDSA, c).SignedString(priv)
-	require.NoError(t, err)
-	return s
+	return authtest.MintToken(t, priv, sub, methodAndPath, lifetime, issuedAt)
 }
 
 func TestAuth_TruthTable(t *testing.T) {

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -178,18 +178,19 @@ func (s *ApiServer) closeServices() {
 func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
 	mux := http.NewServeMux()
 
-	// Initialize health check handler (dependency-free liveness signal)
+	// Health/liveness/readiness probes: registered BARE — never wrapped by Auth.
+	// K8s and the docker-compose wget healthcheck cannot present per-request JWTs,
+	// and db-health is designed never to fail the request; gating any of these
+	// would 401 probes under `--auth-mode strict` and cause pod churn.
 	healthHandler := handlers.NewHealthHandler()
 	mux.HandleFunc("GET /api/v1/ping", handlers.CustomHandler(healthHandler.CheckHealth))
 
-	// Initialize RPC health check handler
 	rpcHealthHandler := handlers.NewRPCHealthHandler(s.rpcService)
 	mux.HandleFunc("GET /api/v1/rpc-health", handlers.CustomHandler(rpcHealthHandler.CheckRPCHealth))
 
-	// Initialize DB health check handler (reports connectivity in the body; never
-	// fails the request, so it can't restart or depool a pod over a DB outage).
-	// Pass a true nil interface when disabled — a nil *pgxpool.Pool boxed in the
-	// interface is not == nil, which would defeat the handler's disabled check.
+	// Pass a true nil interface when the DB is disabled — a nil *pgxpool.Pool
+	// boxed in the interface is not == nil, which would defeat the handler's
+	// disabled check.
 	var dbPinger handlers.DBPinger
 	if s.dbPool != nil {
 		dbPinger = s.dbPool
@@ -197,23 +198,30 @@ func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
 	dbHealthHandler := handlers.NewDBHealthHandler(dbPinger)
 	mux.HandleFunc("GET /api/v1/db-health", handlers.CustomHandler(dbHealthHandler.CheckDBHealth))
 
+	// Every user-facing route runs the auth middleware. `authed` binds one Auth
+	// instance to s.authMode (resolved once in Start); flipping --auth-mode
+	// permissive<->strict moves all of these together. A future user-scoped route
+	// can opt into auth.Required independently by wrapping with its own Auth value.
+	verifier := auth.NewVerifier()
+	authed := middleware.Auth(verifier, s.authMode, s.appMetrics.Auth)
+
 	protocolsHandler := handlers.NewProtocolsHandler(s.cfg.AppConfig.ProtocolsConfigPath)
-	mux.HandleFunc("GET /api/v1/protocols", handlers.CustomHandler(protocolsHandler.GetProtocols))
+	mux.Handle("GET /api/v1/protocols", authed(handlers.CustomHandler(protocolsHandler.GetProtocols)))
 
 	collectiblesHandler := handlers.NewCollectiblesHandler(s.rpcService, s.cfg.AppConfig.MeridianPayTreasureHuntAddress, s.cfg.AppConfig.MeridianPayTreasurePoapAddress, s.cfg.AppConfig.MeridianPayStellarHouseAddress, s.cfg.RpcConfig.MaxConcurrentRPCCalls)
-	mux.HandleFunc("POST /api/v1/collectibles", handlers.CustomHandler(collectiblesHandler.GetCollectibles))
+	mux.Handle("POST /api/v1/collectibles", authed(handlers.CustomHandler(collectiblesHandler.GetCollectibles)))
 
 	ledgerKeyAccountsHandler := handlers.NewLedgerKeyAccountHandler(s.rpcService, s.cfg.AppConfig.MaxLedgerKeyAddresses)
-	mux.HandleFunc("POST /api/v1/ledger-key/accounts", handlers.CustomHandler(ledgerKeyAccountsHandler.GetLedgerKeyAccounts))
+	mux.Handle("POST /api/v1/ledger-key/accounts", authed(handlers.CustomHandler(ledgerKeyAccountsHandler.GetLedgerKeyAccounts)))
 
 	featureFlagsHandler := handlers.NewFeatureFlagsHandler()
-	mux.HandleFunc("GET /api/v1/feature-flags", handlers.CustomHandler(featureFlagsHandler.GetFeatureFlags))
+	mux.Handle("GET /api/v1/feature-flags", authed(handlers.CustomHandler(featureFlagsHandler.GetFeatureFlags)))
 
 	accountBalancesHandler := handlers.NewAccountBalancesHandler(s.walletBackendService, s.cfg.AppConfig.MaxBalanceAddresses)
-	mux.HandleFunc("POST /api/v1/accounts/balances", handlers.CustomHandler(accountBalancesHandler.GetAccountBalances))
+	mux.Handle("POST /api/v1/accounts/balances", authed(handlers.CustomHandler(accountBalancesHandler.GetAccountBalances)))
 
 	tokenPricesHandler := handlers.NewTokenPricesHandler(s.pricesService, s.cfg.PricesConfig.MaxTokensPerRequest)
-	mux.HandleFunc("POST /api/v1/token-prices", handlers.CustomHandler(tokenPricesHandler.GetPrices))
+	mux.Handle("POST /api/v1/token-prices", authed(handlers.CustomHandler(tokenPricesHandler.GetPrices)))
 
 	accountHistoryHandler, err := handlers.NewAccountHistoryHandler(
 		s.walletBackendService,
@@ -223,15 +231,12 @@ func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
 	if err != nil {
 		return nil, fmt.Errorf("init account-history handler: %w", err)
 	}
-	mux.HandleFunc("GET /api/v1/accounts/{address}/transactions", handlers.CustomHandler(accountHistoryHandler.GetAccountTransactions))
+	mux.Handle("GET /api/v1/accounts/{address}/transactions", authed(handlers.CustomHandler(accountHistoryHandler.GetAccountTransactions)))
 
-	// Auth: a guarded endpoint that echoes the authenticated user ID. It exercises
-	// the JWT middleware end-to-end and gives client teams a surface to validate
-	// their JWT construction. s.authMode is resolved once in Start().
-	verifier := auth.NewVerifier()
+	// whoami is a normal user-facing route now; it reads the user ID from context
+	// and reports authenticated:false when absent (permissive anonymous).
 	whoamiHandler := handlers.NewWhoamiHandler()
-	mux.Handle("GET /api/v1/auth/whoami",
-		middleware.Auth(verifier, s.authMode, s.appMetrics.Auth)(handlers.CustomHandler(whoamiHandler.Whoami)))
+	mux.Handle("GET /api/v1/auth/whoami", authed(handlers.CustomHandler(whoamiHandler.Whoami)))
 
 	return mux, nil
 }

--- a/internal/api/serve.go
+++ b/internal/api/serve.go
@@ -175,19 +175,25 @@ func (s *ApiServer) closeServices() {
 	}
 }
 
-func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
-	mux := http.NewServeMux()
+// route describes a single registered API endpoint. It is the single source of
+// truth consumed by both initHandlers (which registers it) and the strict-mode
+// gating guard test (which enumerates it): gated routes are wrapped in the Auth
+// middleware, bare routes are not. Keeping method/pattern/gated together in one
+// table means a newly-added route cannot silently skip the auth guard — it must
+// declare `gated` here, and the test derives its coverage from the same table
+// rather than a hand-maintained parallel list that could drift.
+type route struct {
+	method  string
+	pattern string
+	handler http.Handler
+	gated   bool
+}
 
-	// Health/liveness/readiness probes: registered BARE — never wrapped by Auth.
-	// K8s and the docker-compose wget healthcheck cannot present per-request JWTs,
-	// and db-health is designed never to fail the request; gating any of these
-	// would 401 probes under `--auth-mode strict` and cause pod churn.
-	healthHandler := handlers.NewHealthHandler()
-	mux.HandleFunc("GET /api/v1/ping", handlers.CustomHandler(healthHandler.CheckHealth))
-
-	rpcHealthHandler := handlers.NewRPCHealthHandler(s.rpcService)
-	mux.HandleFunc("GET /api/v1/rpc-health", handlers.CustomHandler(rpcHealthHandler.CheckRPCHealth))
-
+// routes builds the full endpoint table. It constructs each handler with its
+// dependencies but performs no middleware wrapping or mux registration, so both
+// initHandlers and tests can enumerate the routes (and their gated flags) without
+// standing up the auth middleware.
+func (s *ApiServer) routes() ([]route, error) {
 	// Pass a true nil interface when the DB is disabled — a nil *pgxpool.Pool
 	// boxed in the interface is not == nil, which would defeat the handler's
 	// disabled check.
@@ -195,34 +201,17 @@ func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
 	if s.dbPool != nil {
 		dbPinger = s.dbPool
 	}
-	dbHealthHandler := handlers.NewDBHealthHandler(dbPinger)
-	mux.HandleFunc("GET /api/v1/db-health", handlers.CustomHandler(dbHealthHandler.CheckDBHealth))
 
-	// Every user-facing route runs the auth middleware. `authed` binds one Auth
-	// instance to s.authMode (resolved once in Start); flipping --auth-mode
-	// permissive<->strict moves all of these together. A future user-scoped route
-	// can opt into auth.Required independently by wrapping with its own Auth value.
-	verifier := auth.NewVerifier()
-	authed := middleware.Auth(verifier, s.authMode, s.appMetrics.Auth)
+	healthHandler := handlers.NewHealthHandler()
+	rpcHealthHandler := handlers.NewRPCHealthHandler(s.rpcService)
+	dbHealthHandler := handlers.NewDBHealthHandler(dbPinger)
 
 	protocolsHandler := handlers.NewProtocolsHandler(s.cfg.AppConfig.ProtocolsConfigPath)
-	mux.Handle("GET /api/v1/protocols", authed(handlers.CustomHandler(protocolsHandler.GetProtocols)))
-
 	collectiblesHandler := handlers.NewCollectiblesHandler(s.rpcService, s.cfg.AppConfig.MeridianPayTreasureHuntAddress, s.cfg.AppConfig.MeridianPayTreasurePoapAddress, s.cfg.AppConfig.MeridianPayStellarHouseAddress, s.cfg.RpcConfig.MaxConcurrentRPCCalls)
-	mux.Handle("POST /api/v1/collectibles", authed(handlers.CustomHandler(collectiblesHandler.GetCollectibles)))
-
 	ledgerKeyAccountsHandler := handlers.NewLedgerKeyAccountHandler(s.rpcService, s.cfg.AppConfig.MaxLedgerKeyAddresses)
-	mux.Handle("POST /api/v1/ledger-key/accounts", authed(handlers.CustomHandler(ledgerKeyAccountsHandler.GetLedgerKeyAccounts)))
-
 	featureFlagsHandler := handlers.NewFeatureFlagsHandler()
-	mux.Handle("GET /api/v1/feature-flags", authed(handlers.CustomHandler(featureFlagsHandler.GetFeatureFlags)))
-
 	accountBalancesHandler := handlers.NewAccountBalancesHandler(s.walletBackendService, s.cfg.AppConfig.MaxBalanceAddresses)
-	mux.Handle("POST /api/v1/accounts/balances", authed(handlers.CustomHandler(accountBalancesHandler.GetAccountBalances)))
-
 	tokenPricesHandler := handlers.NewTokenPricesHandler(s.pricesService, s.cfg.PricesConfig.MaxTokensPerRequest)
-	mux.Handle("POST /api/v1/token-prices", authed(handlers.CustomHandler(tokenPricesHandler.GetPrices)))
-
 	accountHistoryHandler, err := handlers.NewAccountHistoryHandler(
 		s.walletBackendService,
 		s.cfg.AppConfig.AccountHistoryDefaultLimit,
@@ -231,12 +220,53 @@ func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
 	if err != nil {
 		return nil, fmt.Errorf("init account-history handler: %w", err)
 	}
-	mux.Handle("GET /api/v1/accounts/{address}/transactions", authed(handlers.CustomHandler(accountHistoryHandler.GetAccountTransactions)))
-
-	// whoami is a normal user-facing route now; it reads the user ID from context
-	// and reports authenticated:false when absent (permissive anonymous).
 	whoamiHandler := handlers.NewWhoamiHandler()
-	mux.Handle("GET /api/v1/auth/whoami", authed(handlers.CustomHandler(whoamiHandler.Whoami)))
+
+	return []route{
+		// Health/liveness/readiness probes: gated=false, registered BARE — never
+		// wrapped by Auth. K8s and the docker-compose wget healthcheck cannot present
+		// per-request JWTs, and db-health is designed never to fail the request;
+		// gating any of these would 401 probes under `--auth-mode strict` and cause
+		// pod churn.
+		{http.MethodGet, "/api/v1/ping", handlers.CustomHandler(healthHandler.CheckHealth), false},
+		{http.MethodGet, "/api/v1/rpc-health", handlers.CustomHandler(rpcHealthHandler.CheckRPCHealth), false},
+		{http.MethodGet, "/api/v1/db-health", handlers.CustomHandler(dbHealthHandler.CheckDBHealth), false},
+
+		// User-facing routes: gated=true, wrapped in the shared Auth middleware.
+		// Flipping --auth-mode permissive<->strict moves all of these together.
+		// whoami reads the user ID from context and reports authenticated:false when
+		// absent (permissive anonymous).
+		{http.MethodGet, "/api/v1/protocols", handlers.CustomHandler(protocolsHandler.GetProtocols), true},
+		{http.MethodPost, "/api/v1/collectibles", handlers.CustomHandler(collectiblesHandler.GetCollectibles), true},
+		{http.MethodPost, "/api/v1/ledger-key/accounts", handlers.CustomHandler(ledgerKeyAccountsHandler.GetLedgerKeyAccounts), true},
+		{http.MethodGet, "/api/v1/feature-flags", handlers.CustomHandler(featureFlagsHandler.GetFeatureFlags), true},
+		{http.MethodPost, "/api/v1/accounts/balances", handlers.CustomHandler(accountBalancesHandler.GetAccountBalances), true},
+		{http.MethodPost, "/api/v1/token-prices", handlers.CustomHandler(tokenPricesHandler.GetPrices), true},
+		{http.MethodGet, "/api/v1/accounts/{address}/transactions", handlers.CustomHandler(accountHistoryHandler.GetAccountTransactions), true},
+		{http.MethodGet, "/api/v1/auth/whoami", handlers.CustomHandler(whoamiHandler.Whoami), true},
+	}, nil
+}
+
+func (s *ApiServer) initHandlers() (*http.ServeMux, error) {
+	rts, err := s.routes()
+	if err != nil {
+		return nil, err
+	}
+
+	// One Auth instance, bound to s.authMode (resolved once in Start), wraps every
+	// gated route. A future user-scoped route opts into auth simply by adding itself
+	// to routes() with gated=true.
+	verifier := auth.NewVerifier()
+	authed := middleware.Auth(verifier, s.authMode, s.appMetrics.Auth)
+
+	mux := http.NewServeMux()
+	for _, rt := range rts {
+		h := rt.handler
+		if rt.gated {
+			h = authed(h)
+		}
+		mux.Handle(rt.method+" "+rt.pattern, h)
+	}
 
 	return mux, nil
 }

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/stellar/go-stellar-sdk/txnbuild"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,6 +18,7 @@ import (
 	"github.com/stellar/freighter-backend-v2/internal/auth"
 	"github.com/stellar/freighter-backend-v2/internal/config"
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
+	"github.com/stellar/freighter-backend-v2/internal/types"
 )
 
 // newTestAPIServer builds a fully-initialized ApiServer for handler-level tests
@@ -251,4 +255,48 @@ func mustParseURL(path string) *url.URL {
 		panic(err)
 	}
 	return u
+}
+
+// stubRPCService is a no-network RPCService double so /rpc-health can be invoked
+// in tests without a live RPC endpoint. Only GetHealth is used by CheckRPCHealth.
+type stubRPCService struct{}
+
+func (stubRPCService) Name() string { return "stub-rpc" }
+
+func (stubRPCService) GetHealth(ctx context.Context, network string) (types.GetHealthResponse, error) {
+	return types.GetHealthResponse{Status: types.StatusHealthy}, nil
+}
+
+func (stubRPCService) SimulateTx(ctx context.Context, tx *txnbuild.Transaction, network string) (types.SimulateTransactionResponse, error) {
+	return nil, nil
+}
+
+func (stubRPCService) SimulateInvocation(ctx context.Context, contractId xdr.ScAddress, sourceAccount *txnbuild.SimpleAccount, functionName xdr.ScSymbol, params []xdr.ScVal, timeout txnbuild.TimeBounds, network string) (types.SimulateTransactionResponse, error) {
+	return nil, nil
+}
+
+func (stubRPCService) GetLedgerEntries(ctx context.Context, keys []string, network string) ([]types.LedgerEntryMap, error) {
+	return nil, nil
+}
+
+func TestApiServer_initHandlers_HealthRoutesAnonymousInStrict(t *testing.T) {
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+		AuthMode:                   "strict",
+	}}
+	s := newTestAPIServer(t, cfg)
+	s.rpcService = stubRPCService{} // so /rpc-health can be invoked without a live RPC
+
+	mux, err := s.initHandlers()
+	require.NoError(t, err)
+
+	for _, path := range []string{"/api/v1/ping", "/api/v1/db-health", "/api/v1/rpc-health"} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+			"%s must stay anonymous (no 401) even in strict mode", path)
+		assert.Equal(t, http.StatusOK, rec.Code, "%s should return 200", path)
+	}
 }

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"testing"
 	"time"
 
-	jwtgo "github.com/golang-jwt/jwt/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -21,10 +21,27 @@ import (
 
 	"github.com/stellar/freighter-backend-v2/internal/api/handlers"
 	"github.com/stellar/freighter-backend-v2/internal/auth"
+	"github.com/stellar/freighter-backend-v2/internal/auth/authtest"
 	"github.com/stellar/freighter-backend-v2/internal/config"
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
 	"github.com/stellar/freighter-backend-v2/internal/types"
 )
+
+// testCfg returns the standard handler-test config, varying only the auth mode.
+// Most initHandlers tests differ from each other only in AuthMode, so they share
+// this literal rather than each rebuilding it inline.
+func testCfg(authMode string) *config.Config {
+	return &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+		AuthMode:                   authMode,
+	}}
+}
+
+// wildcardSegment matches a ServeMux path wildcard like {address} so tests can
+// substitute a concrete segment when probing a route pattern.
+var wildcardSegment = regexp.MustCompile(`\{[^}]+\}`)
 
 // newTestAPIServer builds a fully-initialized ApiServer for handler-level tests
 // (registry, metrics, and resolved auth mode), mirroring what Start() sets up so
@@ -90,13 +107,7 @@ func TestApiServer_initServices_RejectsNonPositiveBalanceConcurrency(t *testing.
 }
 
 func TestApiServer_initHandlers(t *testing.T) {
-	cfg := &config.Config{AppConfig: config.AppConfig{
-		ProtocolsConfigPath:        "testdata/protocols.json",
-		AccountHistoryDefaultLimit: 20,
-		AccountHistoryMaxLimit:     100,
-		AuthMode:                   "permissive",
-	}}
-	s := newTestAPIServer(t, cfg)
+	s := newTestAPIServer(t, testCfg("permissive"))
 	mux, err := s.initHandlers()
 	require.NoError(t, err)
 	require.NotNil(t, mux)
@@ -108,13 +119,7 @@ func TestApiServer_initHandlers(t *testing.T) {
 }
 
 func TestApiServer_initHandlers_DoesNotServeMetrics(t *testing.T) {
-	cfg := &config.Config{AppConfig: config.AppConfig{
-		ProtocolsConfigPath:        "testdata/protocols.json",
-		AccountHistoryDefaultLimit: 20,
-		AccountHistoryMaxLimit:     100,
-		AuthMode:                   "permissive",
-	}}
-	s := newTestAPIServer(t, cfg)
+	s := newTestAPIServer(t, testCfg("permissive"))
 	mux, err := s.initHandlers()
 	require.NoError(t, err)
 
@@ -163,13 +168,7 @@ func TestApiServer_initMiddleware(t *testing.T) {
 }
 
 func TestApiServer_initHandlers_RegistersAccountHistoryRoutes(t *testing.T) {
-	cfg := &config.Config{AppConfig: config.AppConfig{
-		ProtocolsConfigPath:        "testdata/protocols.json",
-		AccountHistoryDefaultLimit: 20,
-		AccountHistoryMaxLimit:     100,
-		AuthMode:                   "permissive",
-	}}
-	s := newTestAPIServer(t, cfg)
+	s := newTestAPIServer(t, testCfg("permissive"))
 	mux, err := s.initHandlers()
 	require.NoError(t, err)
 	require.NotNil(t, mux)
@@ -181,17 +180,8 @@ func TestApiServer_initHandlers_RegistersAccountHistoryRoutes(t *testing.T) {
 }
 
 func TestApiServer_initHandlers_WhoamiRouteRespectsAuthMode(t *testing.T) {
-	cfgWith := func(authMode string) *config.Config {
-		return &config.Config{AppConfig: config.AppConfig{
-			ProtocolsConfigPath:        "testdata/protocols.json",
-			AccountHistoryDefaultLimit: 20,
-			AccountHistoryMaxLimit:     100,
-			AuthMode:                   authMode,
-		}}
-	}
-
 	// Permissive: an unauthenticated request passes through.
-	mux, err := newTestAPIServer(t, cfgWith("permissive")).initHandlers()
+	mux, err := newTestAPIServer(t, testCfg("permissive")).initHandlers()
 	require.NoError(t, err)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/auth/whoami", nil))
@@ -199,7 +189,7 @@ func TestApiServer_initHandlers_WhoamiRouteRespectsAuthMode(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "\"authenticated\":false")
 
 	// Strict: an unauthenticated request is rejected.
-	mux, err = newTestAPIServer(t, cfgWith("strict")).initHandlers()
+	mux, err = newTestAPIServer(t, testCfg("strict")).initHandlers()
 	require.NoError(t, err)
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/auth/whoami", nil))
@@ -220,20 +210,11 @@ func TestApiServer_initHandlers_ReturnsErrorOnInvalidConfig(t *testing.T) {
 }
 
 func TestApiServer_initHandlers_UserFacingRoutesRespectAuthMode(t *testing.T) {
-	cfgWith := func(authMode string) *config.Config {
-		return &config.Config{AppConfig: config.AppConfig{
-			ProtocolsConfigPath:        "testdata/protocols.json",
-			AccountHistoryDefaultLimit: 20,
-			AccountHistoryMaxLimit:     100,
-			AuthMode:                   authMode,
-		}}
-	}
-
 	// feature-flags is a dependency-free user-facing GET that returns 200 with no
 	// file or service, so it isolates auth behavior from handler dependencies.
 
 	// Permissive: an anonymous request to a user-facing route passes through.
-	mux, err := newTestAPIServer(t, cfgWith("permissive")).initHandlers()
+	mux, err := newTestAPIServer(t, testCfg("permissive")).initHandlers()
 	require.NoError(t, err)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil))
@@ -247,7 +228,7 @@ func TestApiServer_initHandlers_UserFacingRoutesRespectAuthMode(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code, "permissive: invalid token must 401")
 
 	// Strict: an anonymous request to a previously-open route is rejected.
-	mux, err = newTestAPIServer(t, cfgWith("strict")).initHandlers()
+	mux, err = newTestAPIServer(t, testCfg("strict")).initHandlers()
 	require.NoError(t, err)
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil))
@@ -285,13 +266,7 @@ func (stubRPCService) GetLedgerEntries(ctx context.Context, keys []string, netwo
 }
 
 func TestApiServer_initHandlers_HealthRoutesAnonymousInStrict(t *testing.T) {
-	cfg := &config.Config{AppConfig: config.AppConfig{
-		ProtocolsConfigPath:        "testdata/protocols.json",
-		AccountHistoryDefaultLimit: 20,
-		AccountHistoryMaxLimit:     100,
-		AuthMode:                   "strict",
-	}}
-	s := newTestAPIServer(t, cfg)
+	s := newTestAPIServer(t, testCfg("strict"))
 	s.rpcService = stubRPCService{} // so /rpc-health can be invoked without a live RPC
 
 	mux, err := s.initHandlers()
@@ -306,24 +281,11 @@ func TestApiServer_initHandlers_HealthRoutesAnonymousInStrict(t *testing.T) {
 	}
 }
 
-// mintAPIToken mints a valid Ed25519 JWT bound to a specific method and path.
-// It mirrors the proven token minter in internal/api/middleware/auth_test.go.
+// mintAPIToken mints a valid, full-lifetime GET token via the shared authtest
+// helper, so this package and middleware can't drift on the claims format.
 func mintAPIToken(t *testing.T, priv ed25519.PrivateKey, sub, methodAndPath string) string {
 	t.Helper()
-	now := time.Now()
-	c := auth.Claims{
-		BodyHash:      auth.HashBody(nil), // GET requests have no body
-		MethodAndPath: methodAndPath,
-		RegisteredClaims: jwtgo.RegisteredClaims{
-			Subject:   sub,
-			Issuer:    "freighter-extension",
-			IssuedAt:  jwtgo.NewNumericDate(now),
-			ExpiresAt: jwtgo.NewNumericDate(now.Add(auth.MaxTokenLifetime)),
-		},
-	}
-	s, err := jwtgo.NewWithClaims(jwtgo.SigningMethodEdDSA, c).SignedString(priv)
-	require.NoError(t, err)
-	return s
+	return authtest.MintToken(t, priv, sub, methodAndPath, auth.MaxTokenLifetime, time.Now())
 }
 
 func TestApiServer_initHandlers_ValidTokenPopulatesWhoami(t *testing.T) {
@@ -331,13 +293,7 @@ func TestApiServer_initHandlers_ValidTokenPopulatesWhoami(t *testing.T) {
 	require.NoError(t, err)
 	sub := hex.EncodeToString(pub)
 
-	cfg := &config.Config{AppConfig: config.AppConfig{
-		ProtocolsConfigPath:        "testdata/protocols.json",
-		AccountHistoryDefaultLimit: 20,
-		AccountHistoryMaxLimit:     100,
-		AuthMode:                   "permissive",
-	}}
-	mux, err := newTestAPIServer(t, cfg).initHandlers()
+	mux, err := newTestAPIServer(t, testCfg("permissive")).initHandlers()
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/whoami", nil)
@@ -355,13 +311,7 @@ func TestApiServer_authenticatedRequestKeepsRouteMetricLabel(t *testing.T) {
 	require.NoError(t, err)
 	sub := hex.EncodeToString(pub)
 
-	cfg := &config.Config{AppConfig: config.AppConfig{
-		ProtocolsConfigPath:        "testdata/protocols.json",
-		AccountHistoryDefaultLimit: 20,
-		AccountHistoryMaxLimit:     100,
-		AuthMode:                   "permissive",
-	}}
-	s := newTestAPIServer(t, cfg)
+	s := newTestAPIServer(t, testCfg("permissive"))
 	mux, err := s.initHandlers()
 	require.NoError(t, err)
 	assembled := s.initMiddleware(mux) // full chain incl. Metrics, so r.Pattern is exercised
@@ -381,40 +331,39 @@ func TestApiServer_authenticatedRequestKeepsRouteMetricLabel(t *testing.T) {
 }
 
 // TestApiServer_initHandlers_AllUserFacingRoutesGatedInStrict guards the full set
-// of user-facing routes against one being added (or left) without the shared
-// authed wrapper — a silent fail-open. In strict mode the Auth middleware rejects
-// an anonymous request with 401 BEFORE the handler runs, so this needs no service
-// stubs: the nil services left by newTestAPIServer are never reached. A route
-// registered bare would instead reach its handler (returning 200/404, or panicking
-// on a nil service) and fail this assertion. Health probes are covered separately
-// by TestApiServer_initHandlers_HealthRoutesAnonymousInStrict.
+// of user-facing routes against one being added (or left) without the Auth wrapper
+// — a silent fail-open. It derives its coverage from routes() (the same table
+// initHandlers registers from), so a NEW gated route is probed automatically, and
+// a route added with gated=false is a visible, reviewable decision sitting next to
+// the health probes rather than an invisible omission a hand-maintained list here
+// would miss. In strict mode Auth rejects an anonymous request with 401 BEFORE the
+// handler runs, so this needs no service stubs: the nil services left by
+// newTestAPIServer are never reached. A route registered bare would instead reach
+// its handler (returning 200/404, or panicking on a nil service) and fail this
+// assertion. Health probes (gated=false) are covered separately by
+// TestApiServer_initHandlers_HealthRoutesAnonymousInStrict.
 func TestApiServer_initHandlers_AllUserFacingRoutesGatedInStrict(t *testing.T) {
-	cfg := &config.Config{AppConfig: config.AppConfig{
-		ProtocolsConfigPath:        "testdata/protocols.json",
-		AccountHistoryDefaultLimit: 20,
-		AccountHistoryMaxLimit:     100,
-		AuthMode:                   "strict",
-	}}
-	mux, err := newTestAPIServer(t, cfg).initHandlers()
+	s := newTestAPIServer(t, testCfg("strict"))
+	mux, err := s.initHandlers()
 	require.NoError(t, err)
 
-	userFacing := []struct {
-		method string
-		path   string
-	}{
-		{http.MethodGet, "/api/v1/protocols"},
-		{http.MethodPost, "/api/v1/collectibles"},
-		{http.MethodPost, "/api/v1/ledger-key/accounts"},
-		{http.MethodGet, "/api/v1/feature-flags"},
-		{http.MethodPost, "/api/v1/accounts/balances"},
-		{http.MethodPost, "/api/v1/token-prices"},
-		{http.MethodGet, "/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/transactions"},
-		{http.MethodGet, "/api/v1/auth/whoami"},
-	}
-	for _, r := range userFacing {
+	rts, err := s.routes()
+	require.NoError(t, err)
+
+	gated := 0
+	for _, rt := range rts {
+		if !rt.gated {
+			continue // health probes are covered by HealthRoutesAnonymousInStrict
+		}
+		gated++
+		// Substitute a concrete value for any {wildcard} segment so the request
+		// matches the pattern. Auth runs before path-parameter validation, so any
+		// non-empty segment is enough to reach the 401.
+		path := wildcardSegment.ReplaceAllString(rt.pattern, "probe")
 		rec := httptest.NewRecorder()
-		mux.ServeHTTP(rec, httptest.NewRequest(r.method, r.path, nil))
+		mux.ServeHTTP(rec, httptest.NewRequest(rt.method, path, nil))
 		assert.Equal(t, http.StatusUnauthorized, rec.Code,
-			"%s %s must run the auth middleware (401 for anonymous in strict)", r.method, r.path)
+			"%s %s must run the auth middleware (401 for anonymous in strict)", rt.method, rt.pattern)
 	}
+	require.Positive(t, gated, "expected routes() to contain at least one gated route")
 }

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -379,3 +379,42 @@ func TestApiServer_authenticatedRequestKeepsRouteMetricLabel(t *testing.T) {
 	unknown := testutil.ToFloat64(s.appMetrics.HTTP.RequestsTotal.WithLabelValues("unknown", "GET", "200"))
 	assert.Equal(t, float64(0), unknown, "authed request must not collapse to the unknown handler label")
 }
+
+// TestApiServer_initHandlers_AllUserFacingRoutesGatedInStrict guards the full set
+// of user-facing routes against one being added (or left) without the shared
+// authed wrapper — a silent fail-open. In strict mode the Auth middleware rejects
+// an anonymous request with 401 BEFORE the handler runs, so this needs no service
+// stubs: the nil services left by newTestAPIServer are never reached. A route
+// registered bare would instead reach its handler (returning 200/404, or panicking
+// on a nil service) and fail this assertion. Health probes are covered separately
+// by TestApiServer_initHandlers_HealthRoutesAnonymousInStrict.
+func TestApiServer_initHandlers_AllUserFacingRoutesGatedInStrict(t *testing.T) {
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+		AuthMode:                   "strict",
+	}}
+	mux, err := newTestAPIServer(t, cfg).initHandlers()
+	require.NoError(t, err)
+
+	userFacing := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/protocols"},
+		{http.MethodPost, "/api/v1/collectibles"},
+		{http.MethodPost, "/api/v1/ledger-key/accounts"},
+		{http.MethodGet, "/api/v1/feature-flags"},
+		{http.MethodPost, "/api/v1/accounts/balances"},
+		{http.MethodPost, "/api/v1/token-prices"},
+		{http.MethodGet, "/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/transactions"},
+		{http.MethodGet, "/api/v1/auth/whoami"},
+	}
+	for _, r := range userFacing {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(r.method, r.path, nil))
+		assert.Equal(t, http.StatusUnauthorized, rec.Code,
+			"%s %s must run the auth middleware (401 for anonymous in strict)", r.method, r.path)
+	}
+}

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	jwtgo "github.com/golang-jwt/jwt/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -17,7 +18,6 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	jwtgo "github.com/golang-jwt/jwt/v5"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/handlers"
 	"github.com/stellar/freighter-backend-v2/internal/auth"

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -210,6 +210,41 @@ func TestApiServer_initHandlers_ReturnsErrorOnInvalidConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), "init account-history handler")
 }
 
+func TestApiServer_initHandlers_UserFacingRoutesRespectAuthMode(t *testing.T) {
+	cfgWith := func(authMode string) *config.Config {
+		return &config.Config{AppConfig: config.AppConfig{
+			ProtocolsConfigPath:        "testdata/protocols.json",
+			AccountHistoryDefaultLimit: 20,
+			AccountHistoryMaxLimit:     100,
+			AuthMode:                   authMode,
+		}}
+	}
+
+	// feature-flags is a dependency-free user-facing GET that returns 200 with no
+	// file or service, so it isolates auth behavior from handler dependencies.
+
+	// Permissive: an anonymous request to a user-facing route passes through.
+	mux, err := newTestAPIServer(t, cfgWith("permissive")).initHandlers()
+	require.NoError(t, err)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil))
+	assert.Equal(t, http.StatusOK, rec.Code, "permissive: anonymous must pass")
+
+	// Permissive: a present-but-invalid bearer token is rejected on that route.
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
+	req.Header.Set("Authorization", "Bearer not-a-real-token")
+	mux.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "permissive: invalid token must 401")
+
+	// Strict: an anonymous request to a previously-open route is rejected.
+	mux, err = newTestAPIServer(t, cfgWith("strict")).initHandlers()
+	require.NoError(t, err)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "strict: anonymous must 401")
+}
+
 func mustParseURL(path string) *url.URL {
 	u, err := url.Parse(path)
 	if err != nil {

--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -2,17 +2,22 @@ package api
 
 import (
 	"context"
+	"crypto/ed25519"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	jwtgo "github.com/golang-jwt/jwt/v5"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/handlers"
 	"github.com/stellar/freighter-backend-v2/internal/auth"
@@ -299,4 +304,78 @@ func TestApiServer_initHandlers_HealthRoutesAnonymousInStrict(t *testing.T) {
 			"%s must stay anonymous (no 401) even in strict mode", path)
 		assert.Equal(t, http.StatusOK, rec.Code, "%s should return 200", path)
 	}
+}
+
+// mintAPIToken mints a valid Ed25519 JWT bound to a specific method and path.
+// It mirrors the proven token minter in internal/api/middleware/auth_test.go.
+func mintAPIToken(t *testing.T, priv ed25519.PrivateKey, sub, methodAndPath string) string {
+	t.Helper()
+	now := time.Now()
+	c := auth.Claims{
+		BodyHash:      auth.HashBody(nil), // GET requests have no body
+		MethodAndPath: methodAndPath,
+		RegisteredClaims: jwtgo.RegisteredClaims{
+			Subject:   sub,
+			Issuer:    "freighter-extension",
+			IssuedAt:  jwtgo.NewNumericDate(now),
+			ExpiresAt: jwtgo.NewNumericDate(now.Add(auth.MaxTokenLifetime)),
+		},
+	}
+	s, err := jwtgo.NewWithClaims(jwtgo.SigningMethodEdDSA, c).SignedString(priv)
+	require.NoError(t, err)
+	return s
+}
+
+func TestApiServer_initHandlers_ValidTokenPopulatesWhoami(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	sub := hex.EncodeToString(pub)
+
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+		AuthMode:                   "permissive",
+	}}
+	mux, err := newTestAPIServer(t, cfg).initHandlers()
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/whoami", nil)
+	req.Header.Set("Authorization", "Bearer "+mintAPIToken(t, priv, sub, "GET /api/v1/auth/whoami"))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "\"authenticated\":true")
+	assert.Contains(t, rec.Body.String(), sub)
+}
+
+func TestApiServer_authenticatedRequestKeepsRouteMetricLabel(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	sub := hex.EncodeToString(pub)
+
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+		AuthMode:                   "permissive",
+	}}
+	s := newTestAPIServer(t, cfg)
+	mux, err := s.initHandlers()
+	require.NoError(t, err)
+	assembled := s.initMiddleware(mux) // full chain incl. Metrics, so r.Pattern is exercised
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/feature-flags", nil)
+	req.Header.Set("Authorization", "Bearer "+mintAPIToken(t, priv, sub, "GET /api/v1/feature-flags"))
+	rec := httptest.NewRecorder()
+	assembled.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// The authenticated request must be metered under its real route pattern,
+	// not "unknown" (which is what a pre-routing context fork would have caused).
+	got := testutil.ToFloat64(s.appMetrics.HTTP.RequestsTotal.WithLabelValues("GET /api/v1/feature-flags", "GET", "200"))
+	assert.Equal(t, float64(1), got, "authed request should be counted under its route pattern")
+	unknown := testutil.ToFloat64(s.appMetrics.HTTP.RequestsTotal.WithLabelValues("unknown", "GET", "200"))
+	assert.Equal(t, float64(0), unknown, "authed request must not collapse to the unknown handler label")
 }

--- a/internal/auth/authtest/authtest.go
+++ b/internal/auth/authtest/authtest.go
@@ -1,0 +1,36 @@
+// Package authtest provides shared helpers for minting Ed25519-signed API tokens
+// in tests. The minting logic lives here, in one place, so the api and middleware
+// test packages can't drift out of sync if the claims format ever changes.
+package authtest
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+
+	jwtgo "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/freighter-backend-v2/internal/auth"
+)
+
+// MintToken mints a valid Ed25519 JWT bound to sub and methodAndPath, expiring
+// lifetime after issuedAt. Callers vary lifetime/issuedAt to exercise the expiry
+// and clock-skew paths. The body hash is always the empty-body hash, matching the
+// GET requests these tests issue.
+func MintToken(t testing.TB, priv ed25519.PrivateKey, sub, methodAndPath string, lifetime time.Duration, issuedAt time.Time) string {
+	t.Helper()
+	c := auth.Claims{
+		BodyHash:      auth.HashBody(nil),
+		MethodAndPath: methodAndPath,
+		RegisteredClaims: jwtgo.RegisteredClaims{
+			Subject:   sub,
+			Issuer:    "freighter-extension",
+			IssuedAt:  jwtgo.NewNumericDate(issuedAt),
+			ExpiresAt: jwtgo.NewNumericDate(issuedAt.Add(lifetime)),
+		},
+	}
+	s, err := jwtgo.NewWithClaims(jwtgo.SigningMethodEdDSA, c).SignedString(priv)
+	require.NoError(t, err)
+	return s
+}


### PR DESCRIPTION
## TL;DR

Closes #114. Every user-facing `/api/v1` endpoint now runs the JWT auth middleware, not just `whoami`. Behavior is unchanged by default (`permissive`: anonymous requests still succeed, valid tokens populate user context + auth metrics, present-but-invalid tokens are rejected). Flipping the single `--auth-mode strict` switch now requires a valid JWT on **all** user-facing routes at once — the intended end state once clients send JWTs. The infra health probes (`/ping`, `/db-health`, `/rpc-health`) are deliberately left open in every mode so they can't be locked out.

**Deviation from the ticket:** the issue body lists `/rpc-health` as a route to gate, but this PR exempts it alongside the other health probes for operational safety (see below). Flagging for reviewer sign-off.

**Related:** runbook reconciliation for the broader strict-mode 401 surface — [stellar/wallet-eng-runbooks#20](https://github.com/stellar/wallet-eng-runbooks/pull/20).

<details>
<summary>Implementation details (for agents)</summary>

**What changed:**

- [`internal/api/serve.go`](https://github.com/stellar/freighter-backend-v2/blob/f5abbcd90ade6353cf1da8015da6f13427c345e9/internal/api/serve.go#L178) — `initHandlers()` now binds one shared middleware value `authed := middleware.Auth(verifier, s.authMode, s.appMetrics.Auth)` and wraps each of the 8 user-facing routes with it (`protocols`, `collectibles`, `ledger-key/accounts`, `feature-flags`, `accounts/balances`, `token-prices`, `accounts/{address}/transactions`, `auth/whoami`). The three health probes stay bare `mux.HandleFunc(...)`. whoami's previous bespoke inline `Auth` wrap is folded into the shared value. One shared value = flipping `--auth-mode` moves all wrapped routes together.
- **No changes** to `internal/auth` (verifier, `context.go`), `middleware.Auth`, or the global middleware chain in `initMiddleware`. This is route registration only.
- [`docs/design/2026-06-22-jwt-auth-middleware.md`](https://github.com/stellar/freighter-backend-v2/blob/f5abbcd90ade6353cf1da8015da6f13427c345e9/docs/design/2026-06-22-jwt-auth-middleware.md) rewritten to describe the current state (all user-facing routes gated, health bare), dropping the original #88 in/out-of-scope framing.

**Why per-route (not a global chain middleware):** wrapping per route keeps `Auth` *inside* the mux, so it runs **after** `http.ServeMux` has stamped `r.Pattern`. The outer `Metrics` middleware therefore still reads the real route label for authenticated requests — a global `Auth` above the mux would fork the request via `WithContext` before routing and collapse authenticated traffic to `handler="unknown"`. A regression test guards this.

**`/rpc-health` deviation:** gating it under `strict` risks 401ing a k8s/synthetic probe (pod churn), and `db-health`/`ping`/`rpc-health` are health surfaces that must answer without a JWT. Exempted deliberately. **Follow-up:** confirm in `stellar/kube` whether anything probes `/rpc-health`; if not, gating it later is a one-line change.

**Verification:**
- `go test ./internal/api/...` — all pass. New/changed tests: user-facing route respects auth mode (permissive anonymous→200, permissive invalid-token→401, strict anonymous→401); health probes anonymous in strict; valid token populates whoami (`authenticated:true` + user ID); authenticated request keeps its real `freighter_http_requests_total` handler label (the `r.Pattern` regression guard); and a route-set guard asserting **every** user-facing route 401s anonymously in strict (catches a future route added without `authed(...)`).
- `go build ./...`, `go vet ./internal/api/...`, `gofmt -l` — clean.
- Pre-existing unrelated `internal/services` test failure (`TestNewRPCService_GetLedgerEntry/returns_error_on_network_failure`, an IPv6-vs-IPv4 `localhost` exact-string assertion) fails identically on `main` and is untouched by this branch.

**Follow-ups / out of scope:**
- Runbook reconciliation for the broader strict-mode 401 surface is staged separately in `wallet-eng-runbooks` (4xx-ratio + protocols-probe runbooks).
- Per-request auth logging/metrics enrichment (`user_id`, `iss`) and the mutable auth-context holder that requires are #106, intentionally not here.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
