### PR TITLE
test(auth): guard all user-facing routes stay gated (#114 follow-up)

### DIFF
--- a/internal/api/serve_test.go
+++ b/internal/api/serve_test.go
@@ -379,3 +379,42 @@ func TestApiServer_authenticatedRequestKeepsRouteMetricLabel(t *testing.T) {
 	unknown := testutil.ToFloat64(s.appMetrics.HTTP.RequestsTotal.WithLabelValues("unknown", "GET", "200"))
 	assert.Equal(t, float64(0), unknown, "authed request must not collapse to the unknown handler label")
 }
+
+// TestApiServer_initHandlers_AllUserFacingRoutesGatedInStrict guards the full set
+// of user-facing routes against one being added (or left) without the shared
+// authed wrapper — a silent fail-open. In strict mode the Auth middleware rejects
+// an anonymous request with 401 BEFORE the handler runs, so this needs no service
+// stubs: the nil services left by newTestAPIServer are never reached. A route
+// registered bare would instead reach its handler (returning 200/404, or panicking
+// on a nil service) and fail this assertion. Health probes are covered separately
+// by TestApiServer_initHandlers_HealthRoutesAnonymousInStrict.
+func TestApiServer_initHandlers_AllUserFacingRoutesGatedInStrict(t *testing.T) {
+	cfg := &config.Config{AppConfig: config.AppConfig{
+		ProtocolsConfigPath:        "testdata/protocols.json",
+		AccountHistoryDefaultLimit: 20,
+		AccountHistoryMaxLimit:     100,
+		AuthMode:                   "strict",
+	}}
+	mux, err := newTestAPIServer(t, cfg).initHandlers()
+	require.NoError(t, err)
+
+	userFacing := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/protocols"},
+		{http.MethodPost, "/api/v1/collectibles"},
+		{http.MethodPost, "/api/v1/ledger-key/accounts"},
+		{http.MethodGet, "/api/v1/feature-flags"},
+		{http.MethodPost, "/api/v1/accounts/balances"},
+		{http.MethodPost, "/api/v1/token-prices"},
+		{http.MethodGet, "/api/v1/accounts/GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF/transactions"},
+		{http.MethodGet, "/api/v1/auth/whoami"},
+	}
+	for _, r := range userFacing {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(r.method, r.path, nil))
+		assert.Equal(t, http.StatusUnauthorized, rec.Code,
+			"%s %s must run the auth middleware (401 for anonymous in strict)", r.method, r.path)
+	}
+}


### PR DESCRIPTION
## TL;DR

Optional hardening follow-up to #131: a single test that enumerates **every** user-facing `/api/v1` route and asserts each one rejects an anonymous request in `strict` mode. It exists to catch a future route being added without the shared auth wrapper — a silent "fail-open" where an endpoint ships unauthenticated by accident. Test-only, no production change.

**How involved:** barely — **+39 lines, one table test, no stub, no production change.** It turned out much lighter than feared (see below).

> Stacked on #131 (base = `feat/apply-auth-all-endpoints`). Merge or retarget to `main` after #131 lands.

<details>
<summary>Implementation details (for agents)</summary>

**What changed:** one test appended to `internal/api/serve_test.go` — `TestApiServer_initHandlers_AllUserFacingRoutesGatedInStrict`. It builds the mux with `AuthMode: "strict"` and, for each of the 8 user-facing routes, sends an anonymous request and asserts `401`.

**Why it's cheap (the key insight):** in `strict` mode the `Auth` middleware rejects an anonymous request with 401 **before** the wrapped handler runs. So the test never reaches the handlers — the nil `rpcService`/`walletBackendService`/`pricesService` left by the `newTestAPIServer` helper are never invoked, and **no service stub is needed** (unlike the health-probe test in #131, which does invoke `/rpc-health` and therefore needed a stub). That's why this is ~35 lines instead of a stub-heavy fixture.

**What it catches:** a route registered bare (`mux.HandleFunc` without `authed(...)`) would, in strict, reach its handler instead of 401ing — returning 200/404 or panicking on a nil service — and fail the assertion. This is the fail-open guard the final review flagged as optional.

**Scope boundary:** the complementary direction (health probes must stay anonymous in strict) is already covered by `TestApiServer_initHandlers_HealthRoutesAnonymousInStrict` in #131; this test only covers the gated set.

**Verification:** `go test ./internal/api/...` passes; `gofmt -l` clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
