### PR TITLE
feat(auth): observability metrics + structured logging (#106)

### DIFF
--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -22,11 +22,11 @@ import (
 func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metrics.Auth) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			userID, err := verifier.VerifyHTTPRequest(r)
+			identity, err := verifier.VerifyHTTPRequest(r)
 			switch {
 			case err == nil:
 				metrics.RecordAuth(authMetrics, "authenticated", "ok")
-				r = r.WithContext(auth.ContextWithUserID(r.Context(), userID))
+				r = r.WithContext(auth.ContextWithUserID(r.Context(), identity.UserID))
 
 			case errors.Is(err, auth.ErrNoToken):
 				if mode == auth.Required {

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -80,13 +80,17 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 				// runs upstream of this middleware), surfaced via the verifier's
 				// io.ReadAll. This is a client-controlled condition, so render the
 				// same 413 the body-reading handlers use, not a 500.
-				metrics.RecordAuth(authMetrics, "rejected", "too_large", metrics.SanitizeClient(auth.IssuerFromRequestUnverified(r)))
+				iss := auth.IssuerFromRequestUnverified(r)
+				metrics.RecordAuth(authMetrics, "rejected", "too_large", metrics.SanitizeClient(iss))
+				logger.FieldsFromContext(r.Context()).Set("iss", truncateForLog(iss))
 				httperror.RequestEntityTooLarge("Request body too large", err).Render(w)
 				return
 
 			default:
 				// Operational failure (e.g. reading the body).
-				metrics.RecordAuth(authMetrics, "rejected", "internal", metrics.SanitizeClient(auth.IssuerFromRequestUnverified(r)))
+				iss := auth.IssuerFromRequestUnverified(r)
+				metrics.RecordAuth(authMetrics, "rejected", "internal", metrics.SanitizeClient(iss))
+				logger.FieldsFromContext(r.Context()).Set("iss", truncateForLog(iss))
 				logger.ErrorWithContext(r.Context(), "auth check failed", "error", err)
 				httperror.InternalServerError("An unexpected error occurred", err).Render(w)
 				return

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -26,6 +26,9 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 			switch {
 			case err == nil:
 				metrics.RecordAuth(authMetrics, "authenticated", "ok", metrics.SanitizeClient(identity.Issuer))
+				f := logger.FieldsFromContext(r.Context())
+				f.Set("user_id", identity.UserID)
+				f.Set("iss", identity.Issuer)
 				r = r.WithContext(auth.ContextWithUserID(r.Context(), identity.UserID))
 
 			case errors.Is(err, auth.ErrNoToken):
@@ -45,8 +48,10 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 				reason := auth.Reason(err)
 				iss := auth.IssuerFromRequestUnverified(r)
 				metrics.RecordAuth(authMetrics, "rejected", reason, metrics.SanitizeClient(iss))
+				logger.FieldsFromContext(r.Context()).Set("iss", iss)
 				logger.InfoWithContext(r.Context(), "rejected request with invalid auth token",
 					"reason", reason,
+					"iss", iss,
 					"detail", err.Error(),
 					"method", r.Method,
 					"path", r.URL.Path)

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -3,12 +3,28 @@ package middleware
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/stellar/freighter-backend-v2/internal/api/httperror"
 	"github.com/stellar/freighter-backend-v2/internal/auth"
 	"github.com/stellar/freighter-backend-v2/internal/logger"
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
 )
+
+// maxLoggedIssuerLen bounds the client-controlled iss value written to logs.
+// The iss claim is client-controlled and, on the rejection path, unverified;
+// truncating caps log volume from an oversized claim. The metric label is
+// separately bounded by metrics.SanitizeClient.
+const maxLoggedIssuerLen = 64
+
+// truncateForLog returns s bounded to maxLoggedIssuerLen bytes, cut on a valid
+// UTF-8 boundary, with a marker when truncated.
+func truncateForLog(s string) string {
+	if len(s) <= maxLoggedIssuerLen {
+		return s
+	}
+	return strings.ToValidUTF8(s[:maxLoggedIssuerLen], "") + "…(truncated)"
+}
 
 // Auth returns middleware that verifies the request's JWT against the public key
 // in its `sub` claim. Behavior depends on mode:
@@ -28,7 +44,7 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 				metrics.RecordAuth(authMetrics, "authenticated", "ok", metrics.SanitizeClient(identity.Issuer))
 				f := logger.FieldsFromContext(r.Context())
 				f.Set("user_id", identity.UserID)
-				f.Set("iss", identity.Issuer)
+				f.Set("iss", truncateForLog(identity.Issuer))
 				r = r.WithContext(auth.ContextWithUserID(r.Context(), identity.UserID))
 
 			case errors.Is(err, auth.ErrNoToken):
@@ -48,10 +64,11 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 				reason := auth.Reason(err)
 				iss := auth.IssuerFromRequestUnverified(r)
 				metrics.RecordAuth(authMetrics, "rejected", reason, metrics.SanitizeClient(iss))
-				logger.FieldsFromContext(r.Context()).Set("iss", iss)
+				loggedIss := truncateForLog(iss)
+				logger.FieldsFromContext(r.Context()).Set("iss", loggedIss)
 				logger.InfoWithContext(r.Context(), "rejected request with invalid auth token",
 					"reason", reason,
-					"iss", iss,
+					"iss", loggedIss,
 					"detail", err.Error(),
 					"method", r.Method,
 					"path", r.URL.Path)

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -11,20 +11,27 @@ import (
 	"github.com/stellar/freighter-backend-v2/internal/metrics"
 )
 
-// maxLoggedIssuerLen bounds the client-controlled iss value written to logs.
-// The iss claim is client-controlled and, on the rejection path, unverified;
-// truncating caps log volume from an oversized claim. The metric label is
-// separately bounded by metrics.SanitizeClient.
-const maxLoggedIssuerLen = 64
+// Bounds on client-controlled values written to rejection logs. Both the iss
+// claim and the methodAndPath claim (echoed in a bad_method_path error's detail)
+// are client-controlled and, on the rejection path, unverified; truncating caps
+// log volume from an oversized claim. Metric labels are separately bounded by
+// metrics.SanitizeClient.
+const (
+	maxLoggedIssuerLen = 64
+	maxLoggedDetailLen = 256
+)
 
-// truncateForLog returns s bounded to maxLoggedIssuerLen bytes, cut on a valid
-// UTF-8 boundary, with a marker when truncated.
-func truncateForLog(s string) string {
-	if len(s) <= maxLoggedIssuerLen {
+// truncate returns s bounded to max bytes, cut on a valid UTF-8 boundary, with a
+// marker when truncated.
+func truncate(s string, max int) string {
+	if len(s) <= max {
 		return s
 	}
-	return strings.ToValidUTF8(s[:maxLoggedIssuerLen], "") + "…(truncated)"
+	return strings.ToValidUTF8(s[:max], "") + "…(truncated)"
 }
+
+// truncateForLog bounds an iss value for logging.
+func truncateForLog(s string) string { return truncate(s, maxLoggedIssuerLen) }
 
 // Auth returns middleware that verifies the request's JWT against the public key
 // in its `sub` claim. Behavior depends on mode:
@@ -59,8 +66,9 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 			case errors.Is(err, auth.ErrUnauthorized):
 				// A token was presented but did not verify — always rejected. The
 				// reason drives both the metric label and a structured log line for
-				// per-request diagnosis. err.Error() carries only the failure
-				// category and request method/path, never the token or body bytes.
+				// per-request diagnosis. err.Error() never contains the token or body
+				// bytes, but a bad_method_path error echoes the client-controlled
+				// methodAndPath claim, so the detail is length-bounded before logging.
 				reason := auth.Reason(err)
 				iss := auth.IssuerFromRequestUnverified(r)
 				metrics.RecordAuth(authMetrics, "rejected", reason, metrics.SanitizeClient(iss))
@@ -69,7 +77,7 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 				logger.InfoWithContext(r.Context(), "rejected request with invalid auth token",
 					"reason", reason,
 					"iss", loggedIss,
-					"detail", err.Error(),
+					"detail", truncate(err.Error(), maxLoggedDetailLen),
 					"method", r.Method,
 					"path", r.URL.Path)
 				httperror.Unauthorized("unauthorized", nil).Render(w)

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -25,17 +25,17 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 			identity, err := verifier.VerifyHTTPRequest(r)
 			switch {
 			case err == nil:
-				metrics.RecordAuth(authMetrics, "authenticated", "ok")
+				metrics.RecordAuth(authMetrics, "authenticated", "ok", metrics.SanitizeClient(identity.Issuer))
 				r = r.WithContext(auth.ContextWithUserID(r.Context(), identity.UserID))
 
 			case errors.Is(err, auth.ErrNoToken):
 				if mode == auth.Required {
-					metrics.RecordAuth(authMetrics, "rejected", "no_token")
+					metrics.RecordAuth(authMetrics, "rejected", "no_token", metrics.ClientNone)
 					httperror.Unauthorized("unauthorized", nil).Render(w)
 					return
 				}
 				// Permissive: allow through with no user ID attached.
-				metrics.RecordAuth(authMetrics, "anonymous", "no_token")
+				metrics.RecordAuth(authMetrics, "anonymous", "no_token", metrics.ClientNone)
 
 			case errors.Is(err, auth.ErrUnauthorized):
 				// A token was presented but did not verify — always rejected. The
@@ -43,7 +43,8 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 				// per-request diagnosis. err.Error() carries only the failure
 				// category and request method/path, never the token or body bytes.
 				reason := auth.Reason(err)
-				metrics.RecordAuth(authMetrics, "rejected", reason)
+				iss := auth.IssuerFromRequestUnverified(r)
+				metrics.RecordAuth(authMetrics, "rejected", reason, metrics.SanitizeClient(iss))
 				logger.InfoWithContext(r.Context(), "rejected request with invalid auth token",
 					"reason", reason,
 					"detail", err.Error(),
@@ -57,13 +58,13 @@ func Auth(verifier auth.HTTPRequestVerifier, mode auth.Mode, authMetrics *metric
 				// runs upstream of this middleware), surfaced via the verifier's
 				// io.ReadAll. This is a client-controlled condition, so render the
 				// same 413 the body-reading handlers use, not a 500.
-				metrics.RecordAuth(authMetrics, "rejected", "too_large")
+				metrics.RecordAuth(authMetrics, "rejected", "too_large", metrics.SanitizeClient(auth.IssuerFromRequestUnverified(r)))
 				httperror.RequestEntityTooLarge("Request body too large", err).Render(w)
 				return
 
 			default:
 				// Operational failure (e.g. reading the body).
-				metrics.RecordAuth(authMetrics, "rejected", "internal")
+				metrics.RecordAuth(authMetrics, "rejected", "internal", metrics.SanitizeClient(auth.IssuerFromRequestUnverified(r)))
 				logger.ErrorWithContext(r.Context(), "auth check failed", "error", err)
 				httperror.InternalServerError("An unexpected error occurred", err).Render(w)
 				return

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -9,11 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stellar/freighter-backend-v2/internal/auth"
 	"github.com/stellar/freighter-backend-v2/internal/auth/authtest"
+	"github.com/stellar/freighter-backend-v2/internal/metrics"
 )
 
 const authTestPath = "/api/v1/auth/whoami"
@@ -115,4 +118,47 @@ func TestAuth_OversizedBodyReturns413(t *testing.T) {
 
 	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
 	assert.False(t, reached, "handler must not be reached when the body exceeds the limit")
+}
+
+func TestAuth_ClientLabel(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	sub := hex.EncodeToString(pub)
+	_, otherPriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	mAndP := "GET " + authTestPath
+	now := time.Now()
+	valid := mintToken(t, priv, sub, mAndP, auth.MaxTokenLifetime, now)
+	wrongKey := mintToken(t, otherPriv, sub, mAndP, auth.MaxTokenLifetime, now) // parses, bad signature
+
+	cases := []struct {
+		name       string
+		bearer     string
+		wantResult string
+		wantReason string
+		wantClient string
+	}{
+		{"authenticated", valid, "authenticated", "ok", "freighter-extension"},
+		{"anonymous", "", "anonymous", "no_token", "none"},
+		{"rejected readable iss", wrongKey, "rejected", "bad_signature", "freighter-extension"},
+		{"rejected malformed", "not-a-jwt", "rejected", "malformed", "other"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+			m := metrics.NewAuth(reg)
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+			handler := Auth(auth.NewVerifier(), auth.Permissive, m)(next)
+
+			r := httptest.NewRequest(http.MethodGet, authTestPath, nil)
+			if tc.bearer != "" {
+				r.Header.Set("Authorization", "Bearer "+tc.bearer)
+			}
+			handler.ServeHTTP(httptest.NewRecorder(), r)
+
+			got := testutil.ToFloat64(m.RequestsTotal.WithLabelValues(tc.wantResult, tc.wantReason, tc.wantClient))
+			assert.Equal(t, float64(1), got, "expected one %s/%s/%s", tc.wantResult, tc.wantReason, tc.wantClient)
+		})
+	}
 }

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -7,13 +7,17 @@ import (
 	"github.com/stellar/freighter-backend-v2/internal/logger"
 )
 
-// Logging returns a middleware that logs information about each request
-// It uses a buffered response writer to allow handlers to change status codes
-// even after writing the response body
+// Logging returns a middleware that logs one structured line per request.
+// It seeds a request-scoped logger.Fields holder into the context so downstream
+// middleware (e.g. Auth) can enrich the line with fields like user_id/iss; those
+// fields are appended to the existing keys, never replacing them (log continuity).
 func Logging() Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			startTime := time.Now()
+
+			fields := logger.NewFields()
+			r = r.WithContext(logger.ContextWithFields(r.Context(), fields))
 
 			bw := NewBufferedResponseWriter(w)
 			next.ServeHTTP(bw, r)
@@ -24,12 +28,14 @@ func Logging() Middleware {
 
 			if err != nil {
 				logger.ErrorWithContext(r.Context(), "Request failed to flush response",
-					"status", status,
-					"method", r.Method,
-					"url", r.URL.String(),
-					"duration", duration,
-					"error", err,
-					"bodySize", len(bw.Body()))
+					append([]any{
+						"status", status,
+						"method", r.Method,
+						"url", r.URL.String(),
+						"duration", duration,
+						"error", err,
+						"bodySize", len(bw.Body()),
+					}, fields.Args()...)...)
 			} else if status >= 400 {
 				body := bw.Body()
 				bodyStr := string(body)
@@ -37,19 +43,23 @@ func Logging() Middleware {
 					bodyStr = bodyStr[:1024] + "... (truncated)"
 				}
 				logger.ErrorWithContext(r.Context(), "Request completed with error",
-					"status", status,
-					"method", r.Method,
-					"url", r.URL.String(),
-					"duration", duration,
-					"bodySize", len(body),
-					"body", bodyStr)
+					append([]any{
+						"status", status,
+						"method", r.Method,
+						"url", r.URL.String(),
+						"duration", duration,
+						"bodySize", len(body),
+						"body", bodyStr,
+					}, fields.Args()...)...)
 			} else {
 				logger.InfoWithContext(r.Context(), "Request completed",
-					"status", status,
-					"method", r.Method,
-					"url", r.URL.String(),
-					"duration", duration,
-					"bodySize", len(bw.Body()))
+					append([]any{
+						"status", status,
+						"method", r.Method,
+						"url", r.URL.String(),
+						"duration", duration,
+						"bodySize", len(bw.Body()),
+					}, fields.Args()...)...)
 			}
 		})
 	}

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -25,41 +25,37 @@ func Logging() Middleware {
 
 			duration := time.Since(startTime)
 			status := bw.StatusCode()
+			body := bw.Body()
 
-			if err != nil {
+			// withCommon prefixes the fields shared by every request log line and
+			// appends any request-scoped fields (e.g. user_id/iss) set by downstream
+			// middleware, so each branch specifies only what is unique to it. The
+			// request-scoped fields always come last, preserving the existing key
+			// order (log continuity).
+			withCommon := func(extra ...any) []any {
+				common := []any{
+					"status", status,
+					"method", r.Method,
+					"url", r.URL.String(),
+					"duration", duration,
+				}
+				return append(append(common, extra...), fields.Args()...)
+			}
+
+			switch {
+			case err != nil:
 				logger.ErrorWithContext(r.Context(), "Request failed to flush response",
-					append([]any{
-						"status", status,
-						"method", r.Method,
-						"url", r.URL.String(),
-						"duration", duration,
-						"error", err,
-						"bodySize", len(bw.Body()),
-					}, fields.Args()...)...)
-			} else if status >= 400 {
-				body := bw.Body()
+					withCommon("error", err, "bodySize", len(body))...)
+			case status >= 400:
 				bodyStr := string(body)
 				if len(bodyStr) > 1024 {
 					bodyStr = bodyStr[:1024] + "... (truncated)"
 				}
 				logger.ErrorWithContext(r.Context(), "Request completed with error",
-					append([]any{
-						"status", status,
-						"method", r.Method,
-						"url", r.URL.String(),
-						"duration", duration,
-						"bodySize", len(body),
-						"body", bodyStr,
-					}, fields.Args()...)...)
-			} else {
+					withCommon("bodySize", len(body), "body", bodyStr)...)
+			default:
 				logger.InfoWithContext(r.Context(), "Request completed",
-					append([]any{
-						"status", status,
-						"method", r.Method,
-						"url", r.URL.String(),
-						"duration", duration,
-						"bodySize", len(bw.Body()),
-					}, fields.Args()...)...)
+					withCommon("bodySize", len(body))...)
 			}
 		})
 	}

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 
@@ -88,4 +90,14 @@ func TestLoggingAuth_AnonymousHasNoAuthFields(t *testing.T) {
 	out := buf.String()
 	assert.NotContains(t, out, "user_id=")
 	assert.NotContains(t, out, "iss=")
+}
+
+func TestTruncateForLog(t *testing.T) {
+	assert.Equal(t, "freighter-extension", truncateForLog("freighter-extension"))
+	long := strings.Repeat("a", 200)
+	got := truncateForLog(long)
+	assert.LessOrEqual(t, len(got), maxLoggedIssuerLen+len("…(truncated)"))
+	assert.Contains(t, got, "(truncated)")
+	// multi-byte safe: no invalid UTF-8 in the result
+	assert.True(t, utf8.ValidString(got))
 }

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -2,13 +2,17 @@ package middleware
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stellar/freighter-backend-v2/internal/auth"
 	"github.com/stellar/freighter-backend-v2/internal/logger"
 )
 
@@ -46,4 +50,42 @@ func TestLogging_EmitsSeededFields(t *testing.T) {
 	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/protocols", nil))
 
 	assert.Contains(t, buf.String(), "user_id=deadbeef")
+}
+
+func TestLoggingAuth_AuthenticatedLineHasUserAndIss(t *testing.T) {
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub := hex.EncodeToString(pub)
+	token := mintToken(t, priv, sub, "GET "+authTestPath, auth.MaxTokenLifetime, time.Now())
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := Logging()(Auth(auth.NewVerifier(), auth.Permissive, nil)(next))
+
+	r := httptest.NewRequest(http.MethodGet, authTestPath, nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+
+	out := buf.String()
+	assert.Contains(t, out, "user_id="+sub)
+	assert.Contains(t, out, "iss=freighter-extension")
+}
+
+func TestLoggingAuth_AnonymousHasNoAuthFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := Logging()(Auth(auth.NewVerifier(), auth.Permissive, nil)(next))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, authTestPath, nil))
+
+	out := buf.String()
+	assert.NotContains(t, out, "user_id=")
+	assert.NotContains(t, out, "iss=")
 }

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -131,3 +131,34 @@ func TestLoggingAuth_OversizedBodyLogsIss(t *testing.T) {
 	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
 	assert.Contains(t, buf.String(), "iss=freighter-extension")
 }
+
+// A bad_method_path rejection echoes the client-controlled methodAndPath claim
+// into the log detail. It must be length-bounded so an oversized claim (bounded
+// only by the ~1MB header limit) cannot inflate log volume.
+func TestLoggingAuth_RejectionDetailIsBounded(t *testing.T) {
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub := hex.EncodeToString(pub)
+	// Valid timing + signature, but a huge methodAndPath claim that won't match
+	// the request → bad_method_path, which echoes the claim into the detail.
+	huge := "GET /" + strings.Repeat("a", 5000)
+	token := mintToken(t, priv, sub, huge, auth.MaxTokenLifetime, time.Now())
+
+	r := httptest.NewRequest(http.MethodGet, authTestPath, nil)
+	r.Header.Set("Authorization", "Bearer "+token)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := Logging()(Auth(auth.NewVerifier(), auth.Permissive, nil)(next))
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+
+	out := buf.String()
+	assert.Contains(t, out, "reason=bad_method_path")
+	assert.Contains(t, out, "(truncated)")
+	// The full attacker-controlled claim never reaches the log.
+	assert.NotContains(t, out, strings.Repeat("a", 5000))
+}

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -101,3 +101,33 @@ func TestTruncateForLog(t *testing.T) {
 	// multi-byte safe: no invalid UTF-8 in the result
 	assert.True(t, utf8.ValidString(got))
 }
+
+// The too_large rejection branch must log best-effort iss like the other
+// rejection paths (IssuerFromRequestUnverified reads the header, which survives
+// the oversized-body read that trips this branch).
+func TestLoggingAuth_OversizedBodyLogsIss(t *testing.T) {
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	const limit = 16
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub := hex.EncodeToString(pub)
+	token := mintToken(t, priv, sub, "POST "+authTestPath, auth.MaxTokenLifetime, time.Now())
+
+	rr := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, authTestPath, bytes.NewReader(make([]byte, limit+1)))
+	r.Header.Set("Authorization", "Bearer "+token)
+	// Simulate the upstream BodySizeLimit middleware wrapping the body.
+	r.Body = http.MaxBytesReader(rr, r.Body, limit)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := Logging()(Auth(auth.NewVerifier(), auth.Permissive, nil)(next))
+	handler.ServeHTTP(rr, r)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+	assert.Contains(t, buf.String(), "iss=freighter-extension")
+}

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/freighter-backend-v2/internal/logger"
+)
+
+// Continuity guard (spec §5.1): an anonymous request must emit exactly the
+// pre-existing keys and message, and NO auth fields.
+func TestLogging_AnonymousLineUnchanged(t *testing.T) {
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := Logging()(next)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil))
+
+	out := buf.String()
+	assert.Contains(t, out, "Request completed")
+	for _, key := range []string{"status=", "method=", "url=", "duration=", "bodySize="} {
+		assert.Contains(t, out, key, "existing key %q must remain", key)
+	}
+	assert.NotContains(t, out, "user_id=")
+	assert.NotContains(t, out, "iss=")
+}
+
+// Fields set by a downstream handler must appear on the emitted line.
+func TestLogging_EmitsSeededFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger.FieldsFromContext(r.Context()).Set("user_id", "deadbeef")
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := Logging()(next)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/protocols", nil))
+
+	assert.Contains(t, buf.String(), "user_id=deadbeef")
+}

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -25,9 +25,9 @@ func TestLogging_AnonymousLineUnchanged(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "Request completed")
-	for _, key := range []string{"status=", "method=", "url=", "duration=", "bodySize="} {
-		assert.Contains(t, out, key, "existing key %q must remain", key)
-	}
+	// Existing keys must appear in their original order with word boundaries, so a
+	// reorder or a substring-preserving rename (e.g. status -> req_status) fails.
+	assert.Regexp(t, `\bstatus=\S+ method=\S+ url=\S+ duration=\S+ bodySize=\S+`, out)
 	assert.NotContains(t, out, "user_id=")
 	assert.NotContains(t, out, "iss=")
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -277,9 +277,10 @@ func TestVerifyHTTPRequest_Valid(t *testing.T) {
 	v := NewVerifier()
 	r := newRequest(t, http.MethodPost, "/api/v1/thing", body, token)
 
-	userID, err := v.VerifyHTTPRequest(r)
+	identity, err := v.VerifyHTTPRequest(r)
 	require.NoError(t, err)
-	assert.Equal(t, sub, userID)
+	assert.Equal(t, sub, identity.UserID)
+	assert.Equal(t, "freighter-extension", identity.Issuer)
 
 	// Body must remain readable by downstream handlers.
 	got, err := readAll(r)
@@ -308,9 +309,9 @@ func TestVerifyHTTPRequest_CaseInsensitiveBearer(t *testing.T) {
 	// RFC 6750: the auth scheme is case-insensitive.
 	r.Header.Set("Authorization", "bearer "+token)
 
-	userID, err := v.VerifyHTTPRequest(r)
+	identity, err := v.VerifyHTTPRequest(r)
 	require.NoError(t, err)
-	assert.Equal(t, sub, userID)
+	assert.Equal(t, sub, identity.UserID)
 }
 
 func TestVerifyHTTPRequest_LargeBodyNotTruncated(t *testing.T) {
@@ -321,9 +322,9 @@ func TestVerifyHTTPRequest_LargeBodyNotTruncated(t *testing.T) {
 	token := mint(t, priv, validClaims(sub, "POST /api/v1/thing", body))
 
 	v := NewVerifier()
-	userID, err := v.VerifyHTTPRequest(newRequest(t, http.MethodPost, "/api/v1/thing", body, token))
+	identity, err := v.VerifyHTTPRequest(newRequest(t, http.MethodPost, "/api/v1/thing", body, token))
 	require.NoError(t, err)
-	assert.Equal(t, sub, userID)
+	assert.Equal(t, sub, identity.UserID)
 }
 
 func TestReason(t *testing.T) {

--- a/internal/auth/issuer.go
+++ b/internal/auth/issuer.go
@@ -1,0 +1,33 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+
+	jwtgo "github.com/golang-jwt/jwt/v5"
+)
+
+// IssuerFromRequestUnverified returns the `iss` claim of the request's bearer
+// token parsed WITHOUT signature or timing verification, or "" if there is no
+// bearer token or it cannot be parsed.
+//
+// It reads only the Authorization header (never the body). The result is
+// UNVERIFIED and client-spoofable: use it ONLY for a bounded, best-effort
+// observability label (metric client bucket, log field) on the rejection path —
+// never for an authentication or authorization decision.
+func IssuerFromRequestUnverified(r *http.Request) string {
+	scheme, token, _ := strings.Cut(r.Header.Get("Authorization"), " ")
+	if !strings.EqualFold(scheme, "Bearer") {
+		return ""
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	var claims jwtgo.RegisteredClaims
+	parser := jwtgo.NewParser()
+	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
+		return ""
+	}
+	return claims.Issuer
+}

--- a/internal/auth/issuer_test.go
+++ b/internal/auth/issuer_test.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIssuerFromRequestUnverified(t *testing.T) {
+	_, priv, sub := newKeypair(t)
+	_, otherPriv, _ := newKeypair(t)
+	validToken := mint(t, priv, validClaims(sub, testMethodAndPath, nil))
+	// A token signed by the wrong key still PARSES; iss is readable though the
+	// signature would fail verification.
+	wrongKeyToken := mint(t, otherPriv, validClaims(sub, testMethodAndPath, nil))
+
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"valid token", "Bearer " + validToken, "freighter-extension"},
+		{"bad-signature token (still parseable)", "Bearer " + wrongKeyToken, "freighter-extension"},
+		{"malformed token", "Bearer not-a-jwt", ""},
+		{"no header", "", ""},
+		{"non-bearer scheme", "Basic abc123", ""},
+		{"empty bearer", "Bearer ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := http.NewRequest(http.MethodGet, "/api/v1/auth/whoami", nil)
+			if tc.header != "" {
+				r.Header.Set("Authorization", tc.header)
+			}
+			assert.Equal(t, tc.want, IssuerFromRequestUnverified(r))
+		})
+	}
+}

--- a/internal/auth/verifier.go
+++ b/internal/auth/verifier.go
@@ -9,10 +9,16 @@ import (
 	"strings"
 )
 
+// Identity is the authenticated principal extracted from a verified request JWT.
+type Identity struct {
+	UserID string // hex-encoded auth public key (the JWT `sub`); also the user ID
+	Issuer string // client type (the JWT `iss`), e.g. "freighter-extension"; trusted (from a signature-verified token)
+}
+
 // HTTPRequestVerifier verifies the JWT carried by an HTTP request and returns the
 // authenticated user ID (hex-encoded auth public key).
 type HTTPRequestVerifier interface {
-	VerifyHTTPRequest(r *http.Request) (userID string, err error)
+	VerifyHTTPRequest(r *http.Request) (Identity, error)
 }
 
 // Verifier is the default HTTPRequestVerifier. It holds no key material — the
@@ -31,38 +37,38 @@ func NewVerifier() *Verifier {
 // method+path and body, and verifies it. It returns ErrNoToken when no bearer
 // token is present (so callers can allow anonymous access in permissive mode);
 // any other error indicates a present-but-invalid token.
-func (v *Verifier) VerifyHTTPRequest(r *http.Request) (string, error) {
+func (v *Verifier) VerifyHTTPRequest(r *http.Request) (Identity, error) {
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
-		return "", ErrNoToken
+		return Identity{}, ErrNoToken
 	}
 	// RFC 6750: the "Bearer" auth scheme is case-insensitive.
 	scheme, token, _ := strings.Cut(authHeader, " ")
 	if !strings.EqualFold(scheme, "Bearer") {
 		// A different (or unparseable) auth scheme — not a bearer token this
 		// verifier handles, so treat it as no token (anonymous in permissive mode).
-		return "", ErrNoToken
+		return Identity{}, ErrNoToken
 	}
 	// A Bearer scheme with an empty or whitespace-only credential is a
 	// present-but-invalid token, not "no token": reject it (401 in both modes)
 	// rather than letting permissive mode pass it through as anonymous.
 	token = strings.TrimSpace(token)
 	if token == "" {
-		return "", &VerificationError{Reason: ReasonMalformed, Err: errors.New("empty bearer credential")}
+		return Identity{}, &VerificationError{Reason: ReasonMalformed, Err: errors.New("empty bearer credential")}
 	}
 
 	body, err := readAndResetBody(r)
 	if err != nil {
 		// Operational failure, not an auth failure: don't wrap ErrUnauthorized.
-		return "", fmt.Errorf("reading request body: %w", err)
+		return Identity{}, fmt.Errorf("reading request body: %w", err)
 	}
 
 	methodAndPath := fmt.Sprintf("%s %s", r.Method, r.URL.RequestURI())
 	claims, err := ParseJWT(token, methodAndPath, body)
 	if err != nil {
-		return "", err
+		return Identity{}, err
 	}
-	return claims.Subject, nil
+	return Identity{UserID: claims.Subject, Issuer: claims.Issuer}, nil
 }
 
 // readAndResetBody reads the full body (already bounded upstream by

--- a/internal/auth/verifier.go
+++ b/internal/auth/verifier.go
@@ -15,8 +15,9 @@ type Identity struct {
 	Issuer string // client type (the JWT `iss`), e.g. "freighter-extension"; trusted (from a signature-verified token)
 }
 
-// HTTPRequestVerifier verifies the JWT carried by an HTTP request and returns the
-// authenticated user ID (hex-encoded auth public key).
+// HTTPRequestVerifier verifies the JWT carried by an HTTP request and returns
+// the authenticated Identity: the user ID (hex-encoded auth public key, the
+// JWT `sub`) and the client-type issuer (the JWT `iss`).
 type HTTPRequestVerifier interface {
 	VerifyHTTPRequest(r *http.Request) (Identity, error)
 }

--- a/internal/integrationtests/metrics_test.go
+++ b/internal/integrationtests/metrics_test.go
@@ -102,3 +102,23 @@ func (s *MetricsTestSuite) TestMetricsNotExposedOnPublicAPI() {
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusNotFound, resp.StatusCode, "/metrics must not be served by the public API server")
 }
+
+func (s *MetricsTestSuite) TestAuthMetricHasClientLabel() {
+	t := s.T()
+
+	// Drive a gated route with no token so the auth middleware records a series.
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/protocols", s.apiURL))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	metricsResp, err := http.Get(fmt.Sprintf("%s/metrics", s.metricsURL))
+	require.NoError(t, err)
+	defer func() { _ = metricsResp.Body.Close() }()
+	body, err := io.ReadAll(metricsResp.Body)
+	require.NoError(t, err)
+	bodyStr := string(body)
+
+	require.Contains(t, bodyStr, "freighter_auth_requests_total")
+	require.Contains(t, bodyStr, `client="none"`)
+	require.Contains(t, bodyStr, `result="anonymous"`)
+}

--- a/internal/logger/fields.go
+++ b/internal/logger/fields.go
@@ -1,0 +1,56 @@
+package logger
+
+import (
+	"context"
+	"sync"
+)
+
+// Fields is a request-scoped, mutable set of structured log key/value pairs.
+// The Logging middleware seeds one per request into the context; downstream
+// middleware (e.g. Auth) enrich it, and Logging appends the collected pairs to
+// its single per-request log line. All methods are nil-safe so callers can use
+// FieldsFromContext(ctx).Set(...) without a presence check.
+type Fields struct {
+	mu   sync.Mutex
+	args []any
+}
+
+// NewFields returns an empty holder.
+func NewFields() *Fields { return &Fields{} }
+
+// Set appends a key/value pair. Callers set a given key at most once per request.
+func (f *Fields) Set(key string, value any) {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.args = append(f.args, key, value)
+}
+
+// Args returns a copy of the collected key/value pairs, suitable for splatting
+// into a slog variadic call.
+func (f *Fields) Args() []any {
+	if f == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]any, len(f.args))
+	copy(out, f.args)
+	return out
+}
+
+type fieldsCtxKey struct{}
+
+// ContextWithFields returns a child context carrying f.
+func ContextWithFields(ctx context.Context, f *Fields) context.Context {
+	return context.WithValue(ctx, fieldsCtxKey{}, f)
+}
+
+// FieldsFromContext returns the holder carried by ctx, or nil if none was
+// seeded. The nil result is safe to call Set/Args on.
+func FieldsFromContext(ctx context.Context) *Fields {
+	f, _ := ctx.Value(fieldsCtxKey{}).(*Fields)
+	return f
+}

--- a/internal/logger/fields_test.go
+++ b/internal/logger/fields_test.go
@@ -1,0 +1,35 @@
+package logger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFields_SetAppendsInOrder(t *testing.T) {
+	f := NewFields()
+	f.Set("user_id", "abc")
+	f.Set("iss", "freighter-extension")
+	assert.Equal(t, []any{"user_id", "abc", "iss", "freighter-extension"}, f.Args())
+}
+
+func TestFields_NilReceiverIsSafe(t *testing.T) {
+	var f *Fields
+	assert.NotPanics(t, func() {
+		f.Set("k", "v")
+		assert.Nil(t, f.Args())
+	})
+}
+
+func TestFields_ContextRoundTrip(t *testing.T) {
+	f := NewFields()
+	ctx := ContextWithFields(context.Background(), f)
+	assert.Same(t, f, FieldsFromContext(ctx))
+}
+
+func TestFields_ContextAbsentReturnsNilSafeHolder(t *testing.T) {
+	got := FieldsFromContext(context.Background())
+	assert.Nil(t, got)
+	assert.NotPanics(t, func() { got.Set("k", "v") })
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -66,14 +66,42 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 	}
 }
 
+// Client-type label values for the auth metric. The set is closed so a
+// client-controlled `iss` cannot grow label cardinality without bound.
+const (
+	clientExtension = "freighter-extension"
+	clientMobile    = "freighter-mobile"
+	// ClientNone labels a request that carried no token at all (permissive
+	// anonymous path). Kept distinct from "other" so "has not adopted auth"
+	// is never confused with "token present, client unknown".
+	ClientNone  = "none"
+	clientOther = "other"
+)
+
+// SanitizeClient buckets a JWT `iss` (client type) into the closed allowlist.
+// Anything outside it — including "" — becomes "other". This bounds the
+// cardinality of the client label, which derives from a client-controlled
+// claim. The allowlist mirrors the design doc's `iss` contract; a client that
+// ships a different `iss` shows up as "other" (a useful drift canary).
+func SanitizeClient(iss string) string {
+	switch iss {
+	case clientExtension, clientMobile:
+		return iss
+	default:
+		return clientOther
+	}
+}
+
 // Auth holds JWT authentication metrics. During the client rollout these track
-// adoption (authenticated vs anonymous) and rejection reasons.
+// adoption (authenticated vs anonymous), rejection reasons, and client type.
 type Auth struct {
-	// RequestsTotal counts auth-checked requests, labeled by outcome and reason.
+	// RequestsTotal counts auth-checked requests, labeled by outcome, reason,
+	// and client.
 	//   result: "authenticated" | "anonymous" | "rejected"
 	//   reason: "ok" | "no_token" | "expired" | "bad_signature" | "bad_timing" |
 	//           "bad_method_path" | "bad_body_hash" | "bad_subject" | "malformed" |
 	//           "invalid" | "too_large" | "internal"
+	//   client: "freighter-extension" | "freighter-mobile" | "none" | "other"
 	RequestsTotal *prometheus.CounterVec
 }
 
@@ -82,8 +110,8 @@ func NewAuth(reg prometheus.Registerer) *Auth {
 	a := &Auth{
 		RequestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "freighter_auth_requests_total",
-			Help: "Total number of auth-checked HTTP requests, by result and reason.",
-		}, []string{"result", "reason"}),
+			Help: "Total number of auth-checked HTTP requests, by result, reason, and client.",
+		}, []string{"result", "reason", "client"}),
 	}
 	reg.MustRegister(a.RequestsTotal)
 	return a
@@ -91,11 +119,11 @@ func NewAuth(reg prometheus.Registerer) *Auth {
 
 // RecordAuth records the outcome of an auth check. It is nil-safe so the
 // middleware and its tests can run without a metrics registry.
-func RecordAuth(a *Auth, result, reason string) {
+func RecordAuth(a *Auth, result, reason, client string) {
 	if a == nil {
 		return
 	}
-	a.RequestsTotal.WithLabelValues(result, reason).Inc()
+	a.RequestsTotal.WithLabelValues(result, reason, client).Inc()
 }
 
 // HTTP holds HTTP request metrics.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -123,6 +123,19 @@ func TestRecord_NilServiceDoesNotPanic(t *testing.T) {
 	})
 }
 
+func TestSanitizeClient(t *testing.T) {
+	cases := map[string]string{
+		"freighter-extension": "freighter-extension",
+		"freighter-mobile":    "freighter-mobile",
+		"":                    "other",
+		"freighter-cli":       "other",
+		"attacker-supplied-🦄": "other",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, SanitizeClient(in), "input %q", in)
+	}
+}
+
 func TestUpstreamError_Error(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## TL;DR

Adds the auth observability #106 calls for, scoped to the auth surface (contacts is out of scope — those endpoints don't exist yet).

During the permissive-mode rollout we now have answers to two questions from Prometheus and logs: **are clients sending JWTs, and when they do, are the tokens valid — broken down by client type (extension vs mobile)?** The existing auth counter gains a `client` label, and every request's log line now carries `user_id` and `iss` for authenticated requests (and a best-effort `iss` on rejections).

**Continuity:** log queries are unaffected — no existing log key or message changed; new fields are appended only. On the metric, `freighter_auth_requests_total` gains the `client` label (the metric **name** is unchanged): subset-label selectors (e.g. the `{result="rejected",reason="bad_signature"}` alert) and aggregations over the metric continue to work; only exact-full-label-set joins would notice the added dimension. Since the counter is new (landed in #114), has no runbook/dashboard/recording-rule references yet, and is pre-rollout, there's nothing to migrate.

Note: no client ships JWT auth yet, so today all real traffic reads as anonymous; this instrumentation lands ahead of the client rollout, which is the point.

**Invariant this change upholds:** only the *public* auth key (`user_id`) and client type (`iss`) are ever logged — never token bytes, mnemonics, or private keys, and nothing is retained past the request. Client-controlled values can't hurt us: `iss` is bucketed to a closed allowlist before it becomes a metric label (bounded cardinality), length-capped before it's logged (bounded volume), and never used for an auth decision.

Closes #106.

<details>
<summary>Implementation details (for agents)</summary>

**What changed (file-by-file):**

- **`internal/logger/fields.go`** (new) — a nil-safe, mutex-guarded request-scoped `Fields` holder (`Set`/`Args`/`ContextWithFields`/`FieldsFromContext`). This is the mechanism that lets the `Logging` middleware and the per-route `Auth` middleware cooperate on one log line despite `Logging` being outer to `Auth`: `Logging` seeds a `*Fields` into the context and keeps its own pointer to it, `Auth` mutates the pointed-to struct, `Logging` reads it back after the handler returns.
  https://github.com/stellar/freighter-backend-v2/blob/a0e1ff8791de48a58d45fd04917d981424eb05b7/internal/logger/fields.go
- **`internal/auth/verifier.go`** — `VerifyHTTPRequest` now returns `Identity{UserID, Issuer}` instead of a bare user-ID string, surfacing the `iss` claim (previously parsed then discarded).
  https://github.com/stellar/freighter-backend-v2/blob/a0e1ff8791de48a58d45fd04917d981424eb05b7/internal/auth/verifier.go
- **`internal/auth/issuer.go`** (new) — `IssuerFromRequestUnverified`, a best-effort `iss` extractor (header-only, `ParseUnverified`, never used for an auth decision) for labeling/logging the rejection path.
  https://github.com/stellar/freighter-backend-v2/blob/a0e1ff8791de48a58d45fd04917d981424eb05b7/internal/auth/issuer.go
- **`internal/metrics/metrics.go`** — `freighter_auth_requests_total` gains a `client` label; `RecordAuth` becomes 4-arg; `SanitizeClient` buckets the client-controlled `iss` to a closed allowlist (`freighter-extension`/`freighter-mobile`/`other`), with `none` reserved for no-token requests. Bounds label cardinality (max ~132 series).
  https://github.com/stellar/freighter-backend-v2/blob/a0e1ff8791de48a58d45fd04917d981424eb05b7/internal/metrics/metrics.go
- **`internal/api/middleware/auth.go`** — records the `client` label per branch and sets `user_id`/`iss` log fields; the rejection path adds best-effort `iss` to the metric + failure log. The logged `iss` is length-bounded (`truncateForLog`, 64 chars, rune-safe) since it's client-controlled on an internet-facing path; the metric label is separately bounded by `SanitizeClient`.
  https://github.com/stellar/freighter-backend-v2/blob/a0e1ff8791de48a58d45fd04917d981424eb05b7/internal/api/middleware/auth.go
- **`internal/api/middleware/logging.go`** — seeds the `Fields` holder and appends `fields.Args()` to the end of each existing log call. Existing keys/messages are untouched.
  https://github.com/stellar/freighter-backend-v2/blob/a0e1ff8791de48a58d45fd04917d981424eb05b7/internal/api/middleware/logging.go

**Design rationale** (naming reconciliation, PII/NFR decision, log-continuity guarantee) is summarized in this description; the full design spec and implementation plan were kept out of this PR and are available on request.

**Verification:**
- Unit tests green across `internal/logger`, `internal/auth`, `internal/api/...`, `internal/metrics` (`go test`, `-race` via `make unit-test`). New coverage: `Fields` holder, `Identity`/issuer extraction, `SanitizeClient` table, per-path `client`-label assertions (`TestAuth_ClientLabel`), end-to-end `user_id`/`iss` log presence, and a **continuity guard** (`TestLogging_AnonymousLineUnchanged`) using an ordered word-boundary regex that fails if any existing key is renamed/reordered or an auth field leaks onto an anonymous line.
- Integration test `TestAuthMetricHasClientLabel` added asserting the `client` label on `/metrics`; it requires Docker and runs in CI (not runnable in the dev sandbox — compile-verified via `go vet`).
- `go build ./...`, `go vet ./...`, `gofmt -l` clean.

**Companion doc change (separate repo, not in this PR):** the Contact Sync design doc's Observability section, alert query, and log-field list were reconciled to the deployed names on `wallet-eng-monorepo@piyal/design-docs` (the doc had referenced `freighter_auth_jwt_validations_total` / `freighter_request_duration_seconds`, which were never deployed under those names). Runbooks needed no changes — the auth metric has no runbook references yet.

**Reviewer / bot pre-emption:**
- **Error contracts:** `IssuerFromRequestUnverified` returns `""` (not an error/panic) on a missing/unparseable token — deliberate, it's a best-effort label. All auth *decisions* still flow from the verified path's typed errors.
- **Dependencies:** no new modules — `jwt/v5`, `prometheus`, `testify` are all pre-existing; no duplicate import paths.
- **Sync crypto/IO on the request path:** the only added parse is a cheap unverified base64/JSON decode (`ParseUnverified`, no signature check) and only on the *already-failed* rejection path; no new signature/crypto work on the hot path.
- **Log-handler parity:** production uses the text slog handler (`JSONOutput` is always false), which is what the tests assert; the field-append mechanism is handler-agnostic regardless.

**Pre-PR self-review (auth/token-sensitive):** ran the whole-system routine — state-machine/lifecycle (per-request holder, no cross-request bleed, no key retention), `await`/TOCTOU (synchronous chain, mutex-guarded holder), test fidelity (prod handler == test handler), and replaced-behavior parity (added label/field only). The whole-branch review caught and fixed an unbounded raw-`iss` log-volume issue on the rejection path (now length-capped).

**Follow-ups / out of scope:**
- Contacts instrumentation (`freighter_contacts_operations_total`) — deferred until the contacts endpoints exist.
- The `client` allowlist (`freighter-extension`/`freighter-mobile`) is a forward-looking contract from the design doc; no client emits `iss` yet, so drift (a client shipping a different `iss`) will surface as `client="other"`.

</details>
